### PR TITLE
feat: migrate dropdown v2

### DIFF
--- a/.changeset/lemon-ladybugs-drop.md
+++ b/.changeset/lemon-ladybugs-drop.md
@@ -1,0 +1,7 @@
+---
+"@appsmithorg/design-system": patch
+---
+
+feat: migrate Dropdown v2
+feat: migrate Search Component
+feat: migrate Highlight Text

--- a/packages/design-system/README.md
+++ b/packages/design-system/README.md
@@ -39,7 +39,7 @@ Add css import in the root index css file
 ## Usage
 
 ```jsx
-import { TooltipComponent } from "@appsmithorg/design-system";
+import { TooltipComponent } from "design-system";
 
 <TooltipComponent content="Some useful content 🤷🏽‍♂️">
   Hover here 😁
@@ -48,21 +48,38 @@ import { TooltipComponent } from "@appsmithorg/design-system";
 
 ## Contribute
 
-```
+```bash
 git clone https://github.com/appsmithorg/design-system.git
 ```
 Get all dependencies with
-```
+```bash 
 cd design-system/packages/design-system
 yarn install
 ```
 
 Then run storybook in development and watch mode with
-```
+```bash
 yarn design-system:storybook
 ```
 
-Any stories you write within `design-system/packages/design-system/src/**` will show up here. Happy playground testing!
+Any stories you write within `design-system/packages/design-system/src/**` will show up here. 
+
+To use your local version of the package, run 
+```bash
+yarn link
+```
+in this repository, then copy instruction it outputs into the root directory of the repository you want to use this package in. 
+Run
+```bash
+yarn install 
+```
+again to be able to import the components using 
+
+```jsx
+import { TooltipComponent } from "@appsmithorg/design-system";
+```
+
+Happy playground testing!
 
 
 ## Links

--- a/packages/design-system/README.md
+++ b/packages/design-system/README.md
@@ -39,7 +39,7 @@ Add css import in the root index css file
 ## Usage
 
 ```jsx
-import { TooltipComponent } from "design-system";
+import { TooltipComponent } from "@appsmithorg/design-system";
 
 <TooltipComponent content="Some useful content 🤷🏽‍♂️">
   Hover here 😁

--- a/packages/design-system/README.md
+++ b/packages/design-system/README.md
@@ -46,6 +46,25 @@ import { TooltipComponent } from "@appsmithorg/design-system";
 </TooltipComponent>
 ```
 
+## Contribute
+
+```
+git clone https://github.com/appsmithorg/design-system.git
+```
+Get all dependencies with
+```
+cd design-system/packages/design-system
+yarn install
+```
+
+Then run storybook in development and watch mode with
+```
+yarn design-system:storybook
+```
+
+Any stories you write within `design-system/packages/design-system/src/**` will show up here. Happy playground testing!
+
+
 ## Links
 
 - [Home page](https://www.appsmith.com)

--- a/packages/design-system/src/DropdownV2/DropdownV2.stories.tsx
+++ b/packages/design-system/src/DropdownV2/DropdownV2.stories.tsx
@@ -1,0 +1,65 @@
+import React from "react";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+
+import {
+  Props,
+  Dropdown,
+  DropdownList,
+  DropdownItem,
+  DropdownTrigger,
+} from "./index";
+import { IMenuItemProps, IMenuProps, IPopoverProps } from "@blueprintjs/core";
+
+export default {
+  title: "Design System/Dropdown V2",
+  component: Dropdown,
+} as ComponentMeta<typeof Dropdown>;
+
+const DropdownItemTemplate: ComponentStory<typeof DropdownItem> = (
+  args: IMenuItemProps,
+) => <DropdownItem text={args.text} {...args} />;
+
+export const DropdownItemExample = DropdownItemTemplate.bind({});
+DropdownItemExample.storyName = "Dropdown Item";
+DropdownItemExample.args = {
+  text: "Lorem Ipsum Dolor",
+  onClick: () => {
+    console.log("clicked");
+  },
+};
+
+const DropdownListTemplate: ComponentStory<typeof DropdownList> = (
+  args: IMenuProps,
+) => <DropdownList {...args} />;
+
+export const DropdownListExample = DropdownListTemplate.bind({});
+DropdownListExample.storyName = "Dropdown List";
+DropdownListExample.args = {
+  children: [
+    <DropdownItem key="0" {...DropdownItemExample.args} />,
+    <DropdownItem key="1" {...DropdownItemExample.args} />,
+  ],
+};
+
+const DropdownTriggerTemplate: ComponentStory<typeof DropdownTrigger> = (
+  args: any,
+) => <DropdownTrigger {...args} />;
+
+export const DropdownTriggerExample = DropdownTriggerTemplate.bind({});
+DropdownTriggerExample.storyName = "Dropdown Trigger";
+DropdownTriggerExample.args = {
+  children: <button>Click me</button>,
+};
+
+const DropdownTemplate: ComponentStory<typeof Dropdown> = (
+  args: IPopoverProps & Props,
+) => <Dropdown {...args} />;
+
+export const DropdownExample = DropdownTemplate.bind({});
+DropdownExample.storyName = "Dropdown";
+DropdownExample.args = {
+  children: [
+    <DropdownTrigger key="0" {...DropdownTriggerExample.args} />,
+    <DropdownList key="1" {...DropdownListExample.args} />,
+  ],
+};

--- a/packages/design-system/src/DropdownV2/DropdownV2.stories.tsx
+++ b/packages/design-system/src/DropdownV2/DropdownV2.stories.tsx
@@ -63,3 +63,12 @@ DropdownExample.args = {
     <DropdownList key="1" {...DropdownListExample.args} />,
   ],
 };
+
+export const DropdownWithSearch = DropdownTemplate.bind({});
+DropdownWithSearch.args = {
+  enableSearch: true,
+  children: [
+    <DropdownTrigger key="0" {...DropdownTriggerExample.args} />,
+    <DropdownList key="1" {...DropdownListExample.args} />,
+  ],
+};

--- a/packages/design-system/src/DropdownV2/index.tsx
+++ b/packages/design-system/src/DropdownV2/index.tsx
@@ -1,0 +1,87 @@
+import React from "react";
+import styled from "styled-components";
+import {
+  Popover,
+  Menu,
+  MenuItem,
+  IMenuProps,
+  IMenuItemProps,
+  IPopoverProps,
+} from "@blueprintjs/core";
+
+/**
+ * ----------------------------------------------------------------------------
+ * TYPES
+ *-----------------------------------------------------------------------------
+ */
+
+type Props = {
+  children: React.ReactElement[] | React.ReactElement;
+};
+
+/**
+ * ----------------------------------------------------------------------------
+ * STYLED
+ *-----------------------------------------------------------------------------
+ */
+
+const StyledMenuItem = styled(MenuItem)`
+  margin: 0;
+  padding: 8px;
+`;
+
+const StyledMenu = styled(Menu)`
+  margin: 0;
+  padding: 0;
+`;
+
+/**
+ * ----------------------------------------------------------------------------
+ * COMPONENTS
+ *-----------------------------------------------------------------------------
+ */
+function Dropdown(props: IPopoverProps & Props) {
+  const { children, ...rest } = props;
+
+  const menus =
+    (Array.isArray(children) &&
+      children.find(
+        (child: any) => child.type.displayName === "DropdownList",
+      )) ||
+    undefined;
+
+  const trigger =
+    Array.isArray(children) &&
+    children.find((child: any) => child.type.displayName === "DropdownTrigger");
+
+  return (
+    <Popover
+      {...rest}
+      content={menus}
+      popoverClassName="dropdown-v2"
+      transitionDuration={-1}
+    >
+      {trigger}
+    </Popover>
+  );
+}
+
+function DropdownList(props: IMenuProps) {
+  return <StyledMenu {...props} />;
+}
+
+DropdownList.displayName = "DropdownList";
+
+function DropdownTrigger(props: any) {
+  return <div {...props} />;
+}
+
+DropdownTrigger.displayName = "DropdownTrigger";
+
+function DropdownItem(props: IMenuItemProps) {
+  return <StyledMenuItem {...props} />;
+}
+
+DropdownItem.displayName = "DropdownItem";
+
+export { Dropdown, DropdownList, DropdownItem, DropdownTrigger };

--- a/packages/design-system/src/DropdownV2/index.tsx
+++ b/packages/design-system/src/DropdownV2/index.tsx
@@ -57,6 +57,7 @@ function Dropdown(props: IPopoverProps & Props) {
   return (
     <Popover
       {...rest}
+      canEscapeKeyClose
       content={menus}
       popoverClassName="dropdown-v2"
       transitionDuration={-1}
@@ -84,4 +85,4 @@ function DropdownItem(props: IMenuItemProps) {
 
 DropdownItem.displayName = "DropdownItem";
 
-export { Dropdown, DropdownList, DropdownItem, DropdownTrigger };
+export { Props, Dropdown, DropdownList, DropdownItem, DropdownTrigger };

--- a/packages/design-system/src/DropdownV2/index.tsx
+++ b/packages/design-system/src/DropdownV2/index.tsx
@@ -1,16 +1,17 @@
 import React, { useState } from "react";
 import styled from "styled-components";
+import _ from "lodash";
 import {
-  Popover,
+  IMenuItemProps,
+  IMenuProps,
+  IPopoverProps,
   Menu,
   MenuItem,
-  IMenuProps,
-  IMenuItemProps,
-  IPopoverProps,
+  Popover,
 } from "@blueprintjs/core";
 import SearchComponent from "../SearchComponent";
 import { HighlightText } from "../HighlightText";
-import _ from "lodash";
+import Text, { TextType } from "../Text";
 
 /**
  * ----------------------------------------------------------------------------
@@ -40,6 +41,15 @@ const StyledMenu = styled(Menu)`
   padding: 0;
 `;
 
+const EmptyState = styled(MenuItem)`
+  background-color: var(--ads-color-black-100);
+`;
+
+const EmptyStateText = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
 /**
  * ----------------------------------------------------------------------------
  * COMPONENTS
@@ -47,6 +57,8 @@ const StyledMenu = styled(Menu)`
  */
 function Dropdown(props: IPopoverProps & Props) {
   const { children, enableSearch, searchPlaceholder, ...rest } = props;
+
+  // Find the menu items from the children of dropdown and assign it
   const [menuItems, setMenuItems] = useState(
     (Array.isArray(children) &&
       children.find(
@@ -54,8 +66,9 @@ function Dropdown(props: IPopoverProps & Props) {
       )) ||
       undefined,
   );
-  const [searchValue, setSearchValue] = useState("");
 
+  // handle search and filtering of options on menu items
+  const [searchValue, setSearchValue] = useState("");
   const onOptionSearch = (searchStr: string) => {
     setSearchValue(searchStr);
     const search = searchStr.toLocaleUpperCase();
@@ -67,26 +80,47 @@ function Dropdown(props: IPopoverProps & Props) {
           .includes(search);
       },
     );
-    setMenuItems(
-      <DropdownList {...menuItems?.props}>
-        {filteredOptions.map((option, key) => {
-          const propsWithoutText = _.omit(option.props, ["text"]);
-          return (
-            <DropdownItem
-              {...propsWithoutText}
-              key={key}
+
+    // handle case when search string doesn't have any matches
+    _.isEmpty(filteredOptions)
+      ? setMenuItems(
+          <DropdownList {...menuItems?.props}>
+            <EmptyState
               text={
-                <HighlightText
-                  highlight={search}
-                  text={option.props.text?.toString() || ""}
-                />
+                <EmptyStateText>
+                  <Text color={"var(--ads-color-black-500)"} type={TextType.P1}>
+                    No results found
+                  </Text>
+                  <Text color={"var(--ads-color-black-500)"} type={TextType.P3}>
+                    Try to search a different keyword
+                  </Text>
+                </EmptyStateText>
               }
             />
-          );
-        })}
-      </DropdownList>,
-    );
+          </DropdownList>,
+        )
+      : setMenuItems(
+          <DropdownList {...menuItems?.props}>
+            {filteredOptions.map((option, key) => {
+              const propsWithoutText = _.omit(option.props, ["text"]);
+              // filtered options must highlight the sub string matched in the option
+              return (
+                <DropdownItem
+                  {...propsWithoutText}
+                  key={key}
+                  text={
+                    <HighlightText
+                      highlight={search}
+                      text={option.props.text?.toString() || ""}
+                    />
+                  }
+                />
+              );
+            })}
+          </DropdownList>,
+        );
   };
+
   const trigger = enableSearch ? (
     <SearchComponent
       onSearch={onOptionSearch}

--- a/packages/design-system/src/HighlightText/HighlightText.stories.tsx
+++ b/packages/design-system/src/HighlightText/HighlightText.stories.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+
+import { HighlightText } from "./index";
+
+export default {
+  title: "Design System/Highlight Text",
+  component: HighlightText,
+} as ComponentMeta<typeof HighlightText>;
+
+// eslint-disable-next-line react/function-component-definition
+const Template: ComponentStory<typeof HighlightText> = (args) => (
+  <HighlightText {...args} />
+);
+
+export const HighlightTextExample = Template.bind({});
+HighlightTextExample.storyName = "Highlight Text";
+HighlightTextExample.args = {
+  highlight: "some",
+  text: "here is some highlighted text",
+};

--- a/packages/design-system/src/HighlightText/index.tsx
+++ b/packages/design-system/src/HighlightText/index.tsx
@@ -2,11 +2,8 @@ import React from "react";
 import styled from "styled-components";
 
 const TextHighlighter = styled.mark`
-  --ads-text-highlight-color: var(--ads-color-orange-800);
-  --ads-text-highlight-background: var(--ads-color-orange-100);
-
-  color: var(--ads-text-highlight-color);
-  background-color: var(--ads-text-highlight-background);
+  color: var(--ads-highlight-text-default-text-color);
+  background-color: var(--ads-highlight-text-default-background-color);
 `;
 
 export type HighlightTextProps = {

--- a/packages/design-system/src/HighlightText/index.tsx
+++ b/packages/design-system/src/HighlightText/index.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import styled from "styled-components";
+
+const TextHighlighter = styled.mark`
+  --ads-text-highlight-color: var(--ads-color-orange-800);
+  --ads-text-highlight-background: var(--ads-color-orange-100);
+
+  color: var(--ads-text-highlight-color);
+  background-color: var(--ads-text-highlight-background);
+`;
+
+export type HighlightTextProps = {
+  highlight: string;
+  text: string;
+};
+
+export function HighlightText(props: HighlightTextProps) {
+  const { highlight = "", text = "" } = props;
+  if (!highlight.trim()) {
+    return <span data-testid="t--no-highlight">{text}</span>;
+  }
+  const regex = new RegExp(`(${highlight})`, "gi");
+  const parts: string[] = text.split(regex);
+
+  return (
+    <span>
+      {parts.filter(String).map((part, i) => {
+        return regex.test(part) ? (
+          <TextHighlighter data-testid="t--highlighted-text" key={i}>
+            {part}
+          </TextHighlighter>
+        ) : (
+          <span data-testid="t--non-highlighted-text" key={i}>
+            {part}
+          </span>
+        );
+      })}
+    </span>
+  );
+}

--- a/packages/design-system/src/SearchComponent/SearchComponent.stories.tsx
+++ b/packages/design-system/src/SearchComponent/SearchComponent.stories.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+
+import SearchComponent from "./index";
+
+// TODO: How to write well-typed stories for a class component?
+export default {
+  title: "Design System/Search Input",
+  component: SearchComponent,
+};
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+const Template = (args) => <SearchComponent {...args} />;
+
+export const SearchInput = Template.bind({});
+SearchInput.args = {
+  onSearch: () => {},
+  placeholder: "This is a placeholder",
+  value: "",
+};

--- a/packages/design-system/src/SearchComponent/index.tsx
+++ b/packages/design-system/src/SearchComponent/index.tsx
@@ -1,0 +1,135 @@
+import React from "react";
+import styled from "styled-components";
+import { InputGroup } from "@blueprintjs/core";
+import { debounce } from "lodash";
+import { ReactComponent as CrossIcon } from "assets/icons/ads/cross.svg";
+
+// TODO: Rename this component to SearchInput
+
+interface SearchProps {
+  onSearch: (value: any) => void;
+  placeholder: string;
+  value: string;
+  className?: string;
+  autoFocus?: boolean;
+}
+
+const SearchComponentWrapper = styled.div`
+  position: relative;
+  width: 100%;
+`;
+
+const CrossIconWrapper = styled.div`
+  width: 20px;
+  height: 20px;
+  position: absolute;
+  cursor: pointer;
+  top: 5px;
+  right: 5px;
+  .cross-icon {
+    width: 10px;
+    height: 10px;
+    position: absolute;
+    top: 5px;
+    left: 5px;
+  }
+`;
+
+// Firefox doesn't have a default search cancel button
+const HideDefaultSearchCancelIcon = `
+    // chrome, safari
+    input[type="search"]::-webkit-search-cancel-button {
+      -webkit-appearance: none;
+    }
+
+    // MS-edge
+    input[type="search"]::-ms-clear {
+      appearance: none;
+    }
+`;
+
+const SearchInputWrapper = styled(InputGroup)`
+  &&& {
+    input {
+      border-radius: 0;
+      box-shadow: none;
+      font-size: 12px;
+      color: var(--ads-old-color-gray-10);
+      padding-right: 20px;
+      text-overflow: ellipsis;
+      width: 100%;
+    }
+    input:focus {
+      border: 1.2px solid var(--ads-old-color-fern-green);
+      box-sizing: border-box;
+      width: 100%;
+    }
+
+    input:active {
+      box-shadow: 0px 0px 0px 3px var(--ads-old-color-jagged-ice);
+    }
+    ${HideDefaultSearchCancelIcon}
+    svg {
+      path {
+        fill: var(--ads-old-color-gray-7);
+      }
+    }
+  }
+  width: 100%;
+`;
+
+class SearchComponent extends React.Component<
+  SearchProps,
+  { localValue: string }
+> {
+  onDebouncedSearch = debounce(this.props.onSearch, 400);
+  constructor(props: SearchProps) {
+    super(props);
+    this.state = {
+      localValue: props.value,
+    };
+  }
+  componentDidUpdate(prevProps: Readonly<SearchProps>) {
+    // Reset local state if the value has updated via default value
+    if (prevProps.value !== this.props.value) {
+      this.setState({ localValue: this.props.value });
+    }
+  }
+
+  handleSearch = (
+    event:
+      | React.ChangeEvent<HTMLInputElement>
+      | React.ChangeEvent<HTMLTextAreaElement>,
+  ) => {
+    const search = event.target.value;
+    this.setState({ localValue: search });
+    this.onDebouncedSearch(search);
+  };
+  clearSearch = () => {
+    this.setState({ localValue: "" });
+    this.onDebouncedSearch("");
+  };
+
+  render() {
+    return (
+      <SearchComponentWrapper>
+        <SearchInputWrapper
+          autoFocus={this.props.autoFocus}
+          className={`${this.props.className} t--search-input`}
+          leftIcon="search"
+          onChange={this.handleSearch}
+          placeholder={this.props.placeholder}
+          type="search"
+          value={this.state.localValue}
+        />
+        {/*{this.state.localValue && (*/}
+        {/*  <CrossIconWrapper onClick={this.clearSearch}>*/}
+        {/*    <CrossIcon className="cross-icon" />*/}
+        {/*  </CrossIconWrapper>*/}
+        {/*)}*/}
+      </SearchComponentWrapper>
+    );
+  }
+}
+
+export default SearchComponent;

--- a/packages/design-system/src/themes/default/colors.css
+++ b/packages/design-system/src/themes/default/colors.css
@@ -39,4 +39,12 @@
   --ads-color-red-500 : #F13125;
   --ads-color-red-50 : #FFEAEC;
 
+
+  /*  Old colors */
+  /* TODO: These should go away or be renamed when the more comprehensive color palate is here */
+  --ads-old-color-gray-7: #858282;
+  --ads-old-color-gray-10: #090707;
+  --ads-old-color-fern-green: #50AF6C;
+  --ads-old-color-jagged-ice: #CAECDC;
+
 }

--- a/packages/design-system/src/themes/default/colors.css
+++ b/packages/design-system/src/themes/default/colors.css
@@ -1,7 +1,7 @@
 :root {
   /* orange */
   --ads-color-orange-900 : #B7491A;
-  --ads-color-orange-800 : #D15420;
+  --ads-color-orange-800 : #D15420; /* Secondary */
   --ads-color-orange-700 : #DF5B23;
   --ads-color-orange-600 : #ED6227;
   --ads-color-orange-500 : #F86A2B; /* Primary */

--- a/packages/design-system/src/themes/default/index.css
+++ b/packages/design-system/src/themes/default/index.css
@@ -7,7 +7,7 @@
   /** Naming convention for tokens
   *
   * --ads-<component>-<componentType>-<state>-<property>-<subProperty>
-  * 
+  *
   * component: button, checkbox, dropdown, input, link, list, menu, radio, select, textarea...
   * componentType: primary, secondary...
   * state: hover, focus, active, disabled, default...
@@ -20,4 +20,9 @@
   --ads-text-color: var(--ads-color-black-750);
   --ads-text-heading-color: var(--ads-color-black-850);
   --ads-text-highlight-color: var(--ads-color-black-0);
+
+  /** HighlightText */
+  --ads-highlight-text-default-text-color: var(--ads-color-orange-800);
+  --ads-highlight-text-default-background-color: var(--ads-color-orange-100);
+
 }


### PR DESCRIPTION
## Description

This PR will 
- Migrate DropdownV2 from the ads to here 
- Add a flag that enables search according to [the designs in figma](https://www.figma.com/file/i80YbQLLs5mXthjIHclPpX/Appsmith-Design-System?node-id=10508%3A30677)
- Migrate SearchComponent and HighlightText components because they are dependencies on this feature

Fixes #[14969](https://github.com/appsmithorg/appsmith/issues/14969)

## Type of change

- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

## How Has This Been Tested?

I've tested this out manually on the storybook 

### Text Highlighting 
- full text match 
- random substrings
- substrings include spaces
- substrings include upper and lower case

### Search component 
- all of the above
- limitation: the string needs to be continuous (the `Lorem Dolor` search value will not select the `Lorem Ipsum Dolor` item)

### Dropdown
- limitation: there is not keyboard navigation possible through this yet

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

I haven't ported the existing unit tests over because I'm not sure what our strategy there is. 
