### PR TITLE
fix: enable cross icon

### DIFF
--- a/.changeset/cold-donuts-bow.md
+++ b/.changeset/cold-donuts-bow.md
@@ -2,4 +2,4 @@
 "@appsmithorg/design-system": patch
 ---
 
-Enable cross icon
+Enable cross icon on the Search Component

--- a/.changeset/cold-donuts-bow.md
+++ b/.changeset/cold-donuts-bow.md
@@ -1,0 +1,5 @@
+---
+"@appsmithorg/design-system": patch
+---
+
+Enable cross icon

--- a/packages/design-system/src/SearchComponent/index.tsx
+++ b/packages/design-system/src/SearchComponent/index.tsx
@@ -2,9 +2,7 @@ import React from "react";
 import styled from "styled-components";
 import { InputGroup } from "@blueprintjs/core";
 import { debounce } from "lodash";
-import { ReactComponent as CrossIcon } from "assets/icons/ads/cross.svg";
-
-// TODO: Rename this component to SearchInput
+import { ReactComponent as CrossIcon } from "../assets/icons/ads/cross.svg";
 
 interface SearchProps {
   onSearch: (value: any) => void;
@@ -122,11 +120,11 @@ class SearchComponent extends React.Component<
           type="search"
           value={this.state.localValue}
         />
-        {/*{this.state.localValue && (*/}
-        {/*  <CrossIconWrapper onClick={this.clearSearch}>*/}
-        {/*    <CrossIcon className="cross-icon" />*/}
-        {/*  </CrossIconWrapper>*/}
-        {/*)}*/}
+        {this.state.localValue && (
+          <CrossIconWrapper onClick={this.clearSearch}>
+            <CrossIcon className="cross-icon" />
+          </CrossIconWrapper>
+        )}
       </SearchComponentWrapper>
     );
   }


### PR DESCRIPTION
## Description

This PR enables the 'cross' icon functionality. I had commented it out earlier during the migrations because icons weren't available in the ds repo yet 😓 
Fixes the tests on [this pr](https://github.com/appsmithorg/appsmith/pull/15081) from failing

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Storybook!

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
