### PR TITLE
fix: Treedropdown icon and intent prop type

### DIFF
--- a/.changeset/neat-tigers-sparkle.md
+++ b/.changeset/neat-tigers-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@appsmithorg/design-system": patch
+---
+
+fix: Treedropdown icon and intent prop type

--- a/packages/design-system/src/TreeDropdown/index.tsx
+++ b/packages/design-system/src/TreeDropdown/index.tsx
@@ -19,19 +19,25 @@ import {
   Position,
 } from "@blueprintjs/core";
 import styled from "styled-components";
-import { DropdownOption } from "Dropdown";
 import Icon, { IconSize } from "Icon";
 import { replayHighlightClass } from "Constants/classes";
 import useDSEvent from "Common/hooks/useDSEvent";
 import { DSEventTypes } from "Types/common";
 import { typography } from "Constants/typography";
+import { Intent as BlueprintIntent } from "@blueprintjs/core";
+import { IconName } from "@blueprintjs/icons";
 
-export type TreeDropdownOption = DropdownOption & {
+export type TreeDropdownOption = {
+  label: string;
+  value: string;
+  subText?: string;
+  id?: string;
+  intent?: BlueprintIntent;
   onSelect?: (value: TreeDropdownOption, setter?: Setter) => void;
   children?: TreeDropdownOption[];
   className?: string;
   type?: string;
-  icon?: React.ReactNode;
+  icon?: IconName;
   isChildrenOpen?: boolean;
   selfIndex?: number[];
   args?: Array<any>;


### PR DESCRIPTION
## Description

Package build was failing because of Tree Dropdown props intent and icon type was not correct. Fixed those two in this PR.

Fixes [#15772](https://github.com/appsmithorg/appsmith/issues/15772)


## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Tested the build in local

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
