### PR TITLE
feat: Adds showScrollbarOnlyOnHover functionality as a property to ScrollIndicator

### DIFF
--- a/.changeset/curvy-rules-shave.md
+++ b/.changeset/curvy-rules-shave.md
@@ -1,0 +1,5 @@
+---
+"@appsmithorg/design-system": patch
+---
+
+feat: Adds showScrollbarOnlyOnHover functionality as a property to ScrollIndicator


### PR DESCRIPTION

## Description

Fixes # (issue)

> Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Manually tested

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
