### PR TITLE
fix: issue with line height in TableDropdown

### DIFF
--- a/.changeset/large-horses-smell.md
+++ b/.changeset/large-horses-smell.md
@@ -1,0 +1,5 @@
+---
+"@appsmithorg/design-system": patch
+---
+
+fix: issue with line height in TableDropdown

--- a/packages/design-system/src/DialogComponent/index.tsx
+++ b/packages/design-system/src/DialogComponent/index.tsx
@@ -41,7 +41,7 @@ const StyledDialog = styled(Dialog)<{
       font-weight: ${typography.h1.fontWeight};
       font-size: ${typography.h1.fontSize}px;
       line-height: unset;
-      letter-spacing: ${typography.h1.letterSpacing};
+      letter-spacing: ${typography.h1.letterSpacing}px;
     }
 
     .${Classes.DIALOG_CLOSE_BUTTON} {

--- a/packages/design-system/src/TreeDropdown/TreeDropdown.stories.tsx
+++ b/packages/design-system/src/TreeDropdown/TreeDropdown.stories.tsx
@@ -22,8 +22,7 @@ const options = [
 export const TreeDropdownExample = Template.bind({});
 TreeDropdownExample.storyName = "Tree Dropdown";
 TreeDropdownExample.args = {
-  optionTree: options,
-  selectedValue: "PRIMARY",
   defaultText: "Some default text here",
   onSelect: () => console.log("Selected"),
+  optionTree: options,
 };

--- a/packages/design-system/src/TreeDropdown/index.tsx
+++ b/packages/design-system/src/TreeDropdown/index.tsx
@@ -94,7 +94,7 @@ export const StyledMenu = styled(Menu)`
   .${Classes.MENU_ITEM} {
     border-radius: 0px;
     font-size: 14px;
-    line-height: ${typography.p1.lineHeight};
+    line-height: ${typography.p1.lineHeight}px;
     display: flex;
     align-items: center;
     height: 30px;


### PR DESCRIPTION
The line height variable was used directly without appending the px value to it. When a value is used without a unit, it is assumed to be in rem. 