### PR TITLE
feat: add all icon stories

### DIFF
--- a/.changeset/cuddly-lions-punch.md
+++ b/.changeset/cuddly-lions-punch.md
@@ -1,0 +1,5 @@
+---
+"@appsmithorg/design-system": patch
+---
+
+Feat/add all icon stories

--- a/packages/design-system/.storybook/preview.js
+++ b/packages/design-system/.storybook/preview.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from "react";
 import "normalize.css";
 import "@blueprintjs/icons/lib/css/blueprint-icons.css";
 import "@blueprintjs/core/lib/css/blueprint.css";
@@ -12,9 +12,10 @@ export const parameters = {
       date: /Date$/,
     },
   },
-}
+  // layout: "centered",
+};
 
-const containerStye = {
+const containerStyle = {
   display: "flex",
   width: "100%",
   height: "100%",
@@ -22,10 +23,9 @@ const containerStye = {
   justifyContent: "center",
 };
 
-
 export const decorators = [
   (Story) => (
-    <div style={containerStye}>
+    <div style={containerStyle}>
       <Story />
     </div>
   ),

--- a/packages/design-system/src/Icon/Icon.stories.tsx
+++ b/packages/design-system/src/Icon/Icon.stories.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 
-import IconComponent, { IconSize, IconCollection } from "./index";
+import IconComponent, { IconCollection, IconSize } from "./index";
+import styled from "styled-components";
 
 export default {
   title: "Design System/Icon",
@@ -34,9 +35,42 @@ const Template: ComponentStory<typeof IconComponent> = (args) => (
 );
 
 export const Icon = Template.bind({});
-
 Icon.args = {
   name: "filter",
   size: IconSize.XXXXL,
   fillColor: "gray",
 };
+
+const IconWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  height: 4rem;
+`;
+
+const AllIconsWrapper = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+`;
+
+export const AllIcons = () => {
+  return (
+    <AllIconsWrapper>
+      {IconCollection.map((icon, index) => (
+        <IconWrapper key={index}>
+          <IconComponent name={icon} size={IconSize.XXXXL} />
+          <p>{icon}</p>
+        </IconWrapper>
+      ))}
+    </AllIconsWrapper>
+  );
+};
+
+AllIcons.decorators = [
+  (Story) => (
+    <div style={{ height: "75%", width: "25%" }}>
+      <Story />
+    </div>
+  ),
+];


### PR DESCRIPTION
## Description

This PR adds a story that displays a list of all available icons in the system for easy perusal

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Locally on storybook
