### PR TITLE
fix:IconSelector onSelect function failing in local

### DIFF
--- a/.changeset/strong-penguins-change.md
+++ b/.changeset/strong-penguins-change.md
@@ -1,0 +1,5 @@
+---
+"@appsmithorg/design-system": patch
+---
+
+fix:IconSelector onSelect failure in local development

--- a/packages/design-system/src/IconSelector/index.tsx
+++ b/packages/design-system/src/IconSelector/index.tsx
@@ -63,6 +63,7 @@ function IconSelector(props: IconSelectorProps) {
   const [selected, setSelected] = useState<AppIconName>(firstSelectedIcon());
   const iconPaletteRef = React.createRef<HTMLDivElement>();
   const [iconPalette, setIconPalette] = useState(props.iconPalette);
+  const { onSelect } = props;
 
   useEffect(() => {
     if (props.selectedIcon && iconRef.current) {
@@ -112,7 +113,7 @@ function IconSelector(props: IconSelectorProps) {
               onClick={() => {
                 if (iconName !== selected) {
                   setSelected(iconName);
-                  props.onSelect && props.onSelect(iconName);
+                  onSelect && onSelect(iconName);
                 }
               }}
               selectedColor={selected === iconName ? props.selectedColor : ""}


### PR DESCRIPTION
## Description

Destructured props to use onSelect inside onClick, this will fix the issue of throwing withConfig error in local development

Fixes [#16390](https://github.com/appsmithorg/appsmith/issues/16390)

## Type of change

- Bug fix (non-breaking change which fixes an issue)\

## How Has This Been Tested?

- Tested in local using yalc

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
