### PR TITLE
fix: issue with default image being zoomed in on the Display Image Upload component

### DIFF
--- a/.changeset/late-swans-whisper.md
+++ b/.changeset/late-swans-whisper.md
@@ -1,0 +1,5 @@
+---
+"@appsmithorg/design-system": patch
+---
+
+fix: issue with default image being zoomed in on the Display Image Upload component

--- a/packages/design-system/src/DisplayImageUpload/index.tsx
+++ b/packages/design-system/src/DisplayImageUpload/index.tsx
@@ -160,7 +160,7 @@ export default function DisplayImageUpload({
           <div className="view">
             <div className="image-view">
               {!value || loadError ? (
-                <ProfileImagePlaceholder />
+                <ProfileImagePlaceholder style={{ width: "35px" }} />
               ) : (
                 <img
                   onError={() => {


### PR DESCRIPTION
Add width to svg via css