### PR TITLE
fix: AppIcon story not showing in storybook

### DIFF
--- a/.changeset/fifty-goats-march.md
+++ b/.changeset/fifty-goats-march.md
@@ -1,0 +1,5 @@
+---
+"@appsmithorg/design-system": patch
+---
+
+fix: AppIcon story not showing in storybook

--- a/packages/design-system/src/AppIcon/AppIcon.stories.tsx
+++ b/packages/design-system/src/AppIcon/AppIcon.stories.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 
-import AppIconComponent, { Size } from "./index";
+import AppIconComponent from "./index";
 
 export default {
   title: "Design System/AppIcon",
@@ -16,5 +16,5 @@ const Template: ComponentStory<typeof AppIconComponent> = (args) => {
 export const AppIcon = Template.bind({});
 AppIcon.args = {
   name: "arrow-down",
-  size: Size.large,
+  size: "large",
 };


### PR DESCRIPTION
## Description

AppIcon story was not showing up because of the wrong import of Size. have fixed in this PR and the story is now showing up.

Fixes [#16568](https://github.com/appsmithorg/appsmith/issues/16568)


## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Tested in storybook

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
