### PR TITLE
fix: destructure onClick on migrating CalloutV2

### DIFF
--- a/.changeset/stale-bees-matter.md
+++ b/.changeset/stale-bees-matter.md
@@ -1,0 +1,5 @@
+---
+"@appsmithorg/design-system": patch
+---
+
+fix: destructure onClick on migrating CalloutV2

--- a/packages/design-system/src/CalloutV2/index.tsx
+++ b/packages/design-system/src/CalloutV2/index.tsx
@@ -76,20 +76,21 @@ const ContentWrapper = styled.div`
 function CalloutV2(props: {
   actionLabel?: string;
   desc: string;
-  onClick?: any;
+  onClick?: React.MouseEvent<HTMLElement>;
   showCrossIcon?: boolean;
   title?: string;
   type: CalloutType;
   url?: string;
 }) {
-  const linkProps: Record<string, string | (() => any)> = {};
+  const linkProps: Record<string, string | any> = {};
   const [show, setShow] = useState(true);
+  const { onClick } = props;
 
   if (props.url) {
     linkProps.href = props.url;
     linkProps.target = "_blank";
-  } else if (props.onClick) {
-    linkProps.onClick = props.onClick;
+  } else if (onClick) {
+    linkProps.onClick = onClick;
   }
 
   const handleClick = () => {


### PR DESCRIPTION
Migrating CalloutV2 - destructure onClick prop, use better prop types