### PR TITLE
fix: Type for position prop of TreeDropdown

### DIFF
--- a/packages/design-system/src/TreeDropdown/index.tsx
+++ b/packages/design-system/src/TreeDropdown/index.tsx
@@ -16,7 +16,6 @@ import {
   Menu,
   Button,
   Classes,
-  Position,
 } from "@blueprintjs/core";
 import styled from "styled-components";
 import Icon, { IconSize } from "Icon";
@@ -64,7 +63,7 @@ export type TreeDropdownProps = {
   className?: string;
   modifiers?: IPopoverSharedProps["modifiers"];
   onMenuToggle?: (isOpen: boolean) => void;
-  position?: Position;
+  position?: PopoverPosition;
   menuWidth?: number;
 };
 


### PR DESCRIPTION
Makes use of type `PopoverPosition` instead of `Position` in TreeDropdown so that value "auto" will also be accepted by the prop.
