### PR TITLE
fix: destructure file picker functions so that they don't throw errors on local

### DIFF
--- a/.changeset/shaggy-seas-walk.md
+++ b/.changeset/shaggy-seas-walk.md
@@ -1,0 +1,5 @@
+---
+"@appsmithorg/design-system": patch
+---
+
+fix: destructure file picker functions so that they don't throw errors on local

--- a/packages/design-system/src/FilePickerV2/index.tsx
+++ b/packages/design-system/src/FilePickerV2/index.tsx
@@ -194,7 +194,7 @@ const UploadIconWrapper = styled.div`
 `;
 
 function FilePickerComponent(props: FilePickerProps) {
-  const { fileType, logoUploadError } = props;
+  const { fileType, logoUploadError, onFileRemoved, onFileUploaded, fileUploader } = props;
   const [fileInfo, setFileInfo] = useState<{ name: string; size: number }>({
     name: "",
     size: 0,
@@ -257,7 +257,7 @@ function FilePickerComponent(props: FilePickerProps) {
   }
 
   function onUpload(url: string) {
-    props.onFileUploaded && props.onFileUploaded(url);
+    onFileUploaded && onFileUploaded(url);
   }
 
   function handleFileUpload(files: FileList | null) {
@@ -286,7 +286,7 @@ function FilePickerComponent(props: FilePickerProps) {
     if (fileContainerRef.current) {
       fileContainerRef.current.style.display = "none";
     }
-    props.fileUploader && props.fileUploader(file, setProgress, onUpload);
+    fileUploader && fileUploader(file, setProgress, onUpload);
   }
 
   function handleImageFileUpload(files: FileList | null) {
@@ -314,7 +314,7 @@ function FilePickerComponent(props: FilePickerProps) {
       }
 
       /* set form data and send api request */
-      props.fileUploader && props.fileUploader(file, setProgress, onUpload);
+      fileUploader && fileUploader(file, setProgress, onUpload);
     } else {
       Toaster.show({
         text: createMessage(ERROR_FILE_TOO_LARGE, "250 KB"),
@@ -334,7 +334,7 @@ function FilePickerComponent(props: FilePickerProps) {
         bgRef.current.style.backgroundImage = "url('')";
       }
       setIsUploaded(false);
-      props.onFileRemoved && props.onFileRemoved();
+      onFileRemoved && onFileRemoved();
     }
   }
 


### PR DESCRIPTION
## Description

Fixes https://github.com/appsmithorg/appsmith/issues/17584

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Locally by developer

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
