### PR TITLE
fix: issue with font of toasts on windows machines

### DIFF
--- a/.changeset/plenty-dingos-walk.md
+++ b/.changeset/plenty-dingos-walk.md
@@ -1,0 +1,5 @@
+---
+"@appsmithorg/design-system": patch
+---
+
+fix: issue with font of toasts on windows machines

--- a/packages/design-system/src/constants/typography.ts
+++ b/packages/design-system/src/constants/typography.ts
@@ -177,4 +177,4 @@ export enum FontStyleTypes {
 }
 
 export const TextFonts =
-  "-apple-system, BlinkMacSystemFont, “Segoe UI”, “Roboto”, “Oxygen”, “Ubuntu”, “Cantarell”, “Fira Sans”, “Droid Sans”, “Helvetica Neue”";
+  "-apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue";


### PR DESCRIPTION
## Description

Remove bad ascii character double quotes.
Fixes #17645

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

By releasing an alpha version on the dp 

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
