### PR TITLE
fix: Update options in the tree dropdown when the list gets updated

### DIFF
--- a/packages/design-system/src/TreeDropdown/index.tsx
+++ b/packages/design-system/src/TreeDropdown/index.tsx
@@ -281,6 +281,9 @@ function TreeDropdown(props: TreeDropdownProps) {
   const [optionTree, setOptionTree] = useState<TreeDropdownOption[]>(
     setSelfIndex(props.optionTree),
   );
+  useEffect(() => {
+    setOptionTree(setSelfIndex(props.optionTree));
+  }, [props.optionTree]);
   const selectedOptionFromProps = getSelectedOption(
     selectedValue,
     defaultText,


### PR DESCRIPTION
## Description

The options in the tree dropdown were not updating when the options tree was getting updated. Adding a `useEffect` takes care of the issue.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
