### PR TITLE
fix: update hover, focus, type styles on link

### DIFF
--- a/.changeset/breezy-parents-know.md
+++ b/.changeset/breezy-parents-know.md
@@ -1,0 +1,5 @@
+---
+"@appsmithorg/design-system": patch
+---
+
+fix: update hover, focus, type styles on link

--- a/.changeset/giant-keys-burn.md
+++ b/.changeset/giant-keys-burn.md
@@ -1,0 +1,5 @@
+---
+"@appsmithorg/design-system": patch
+---
+
+feat: remove oldest grays, change some stories to reflect those grays

--- a/packages/design-system/src/Button/index.tsx
+++ b/packages/design-system/src/Button/index.tsx
@@ -475,7 +475,7 @@ const ButtonStyles = css<ButtonProps>`
     margin-left: auto;
     margin-right: auto;
     circle {
-      stroke: var(--ads-old-color-gray-7);
+      stroke: var(--ads-color-gray-5);
     }
   }
   .t--right-icon {

--- a/packages/design-system/src/ButtonTab/ButtonTab.stories.tsx
+++ b/packages/design-system/src/ButtonTab/ButtonTab.stories.tsx
@@ -48,6 +48,7 @@ ButtonTabWithLabel.args = {
     {
       label: "LEFT",
       value: "left",
+      selected: true,
     },
   ],
   values: ["left"],

--- a/packages/design-system/src/Checkbox/index.tsx
+++ b/packages/design-system/src/Checkbox/index.tsx
@@ -135,7 +135,7 @@ export const LabelContainer = styled.div<{ info?: string }>`
   display: flex;
   flex-direction: column;
   .${Classes.TEXT}:first-child {
-    color: var(--ads-api-pane-settings-text-color);
+    color: var(--ads-checkbox-label-first-child-text-color);
   }
   ${(props) =>
     props.info

--- a/packages/design-system/src/Dropdown/Dropdown.stories.tsx
+++ b/packages/design-system/src/Dropdown/Dropdown.stories.tsx
@@ -27,6 +27,7 @@ const selected = [
   {
     label: "One",
     value: "one",
+    subText: "some text",
   },
 ];
 
@@ -41,4 +42,5 @@ DropdownExample.args = {
   options: options,
   selected: selected,
   showLabelOnly: true,
+  headerLabel: "A Header",
 };

--- a/packages/design-system/src/Dropdown/index.tsx
+++ b/packages/design-system/src/Dropdown/index.tsx
@@ -333,7 +333,7 @@ export const DropdownWrapper = styled.div<{
     input {
       height: 32px;
       font-size: 14px !important;
-      color: var(--ads-old-color-gray-10) !important;
+      color: var(--ads-color-gray-7) !important;
       padding-left: 36px !important;
       border: 1.2px solid var(--ads-color-black-200);
       &:hover {
@@ -505,7 +505,7 @@ const LeftIconWrapper = styled.span`
 `;
 
 const HeaderWrapper = styled.div`
-  color: var(--ads-old-color-dove-gray);
+  color: var(--ads-color-gray-5);
   font-size: 10px;
   padding: 0px 7px 7px 7px;
 `;

--- a/packages/design-system/src/FilePickerV2/index.tsx
+++ b/packages/design-system/src/FilePickerV2/index.tsx
@@ -385,6 +385,7 @@ function FilePickerComponent(props: FilePickerProps) {
         {props.title || "Drag & Drop files to upload or"}
       </Text>
       {props.description && (
+        // TODO: This is helper text and should be gray-5
         <Text className="drag-drop-description" type={TextType.P2}>
           {props.description}
         </Text>

--- a/packages/design-system/src/Link/Link.stories.tsx
+++ b/packages/design-system/src/Link/Link.stories.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+
+import Link from "./index";
+
+export default {
+  // change ComponentDisplay to the name of the component you are writing a story for
+  title: "Design System/Link",
+  component: Link,
+} as ComponentMeta<typeof Link>;
+
+// eslint-disable-next-line react/function-component-definition
+const Template: ComponentStory<typeof Link> = (args) => {
+  return <Link {...args} />;
+};
+
+export const LinkExample = Template.bind({});
+LinkExample.storyName = "Link";
+LinkExample.args = {
+  to: "www.appsmith.com",
+  children: "a link",
+};
+
+// export const LinkExample = <Link to="www.appsmith.com">a link</Link>;

--- a/packages/design-system/src/Link/index.tsx
+++ b/packages/design-system/src/Link/index.tsx
@@ -23,6 +23,7 @@ const StyledLink = styled.a<{ isPrimary?: boolean }>`
     color: var(--current-color);
     text-decoration: none;
     border-bottom: 1px solid var(--current-color);
+    margin-bottom: -1px;
   }
 
   // hide outline for mouse, touch, or stylus usage
@@ -35,6 +36,7 @@ const StyledLink = styled.a<{ isPrimary?: boolean }>`
     color: var(--current-color);
     outline: 1px solid var(--current-color);
     border-bottom: 1px solid var(--current-color);
+    margin-bottom: -1px;
   }
 `;
 

--- a/packages/design-system/src/Link/index.tsx
+++ b/packages/design-system/src/Link/index.tsx
@@ -1,5 +1,5 @@
-import React, { ReactNode } from "react";
-import styled, { css } from "styled-components";
+import React from "react";
+import styled from "styled-components";
 import Text, { TextProps, TextType } from "Text";
 import { CommonComponentProps } from "Types/common";
 
@@ -33,9 +33,10 @@ const StyledLink = styled.a<{ isPrimary?: boolean }>`
   }
 `;
 
-const Link = ({ children, isPrimary, to }: LinkProps) => {
+const Link = ({ children, isPrimary, to, ...rest }: LinkProps) => {
+  // TODO: evaluate `to` prop and assign to RouterLink or a based on type?
   return (
-    <StyledLink href={to} isPrimary={isPrimary}>
+    <StyledLink href={to} isPrimary={isPrimary} {...rest}>
       {children}
     </StyledLink>
   );

--- a/packages/design-system/src/Link/index.tsx
+++ b/packages/design-system/src/Link/index.tsx
@@ -24,6 +24,10 @@ const StyledLink = styled.a<{ isPrimary?: boolean }>`
   }
 
   &:focus {
+    outline: none;
+  }
+
+  &:focus-visible {
     color: var(--current-color);
     outline: 1px solid var(--current-color);
     border-bottom: 1px solid var(--current-color);

--- a/packages/design-system/src/Link/index.tsx
+++ b/packages/design-system/src/Link/index.tsx
@@ -1,16 +1,19 @@
 import React, { ReactFragment } from "react";
 import styled from "styled-components";
 import { CommonComponentProps } from "Types/common";
+import { TextType } from "../Text";
+import { typography } from "Constants/typography";
 
 export interface LinkProps extends CommonComponentProps {
   children: string | ReactFragment;
   to: string;
   isPrimary?: boolean;
+  textType?: TextType;
   // allow any number of other arguments (classes, styles, etc)
   [x: string]: any;
 }
 
-const StyledLink = styled.a<{ isPrimary?: boolean }>`
+const StyledLink = styled.a<{ isPrimary?: boolean; textType?: TextType }>`
   // explicitly set color instead of relying on css current color property
   --current-color: ${(props) =>
     props.isPrimary
@@ -18,6 +21,8 @@ const StyledLink = styled.a<{ isPrimary?: boolean }>`
       : "var(--ads-text-color-default)"};
 
   color: var(--current-color);
+  font-size: ${(props) =>
+    props.textType ? `${typography[props.textType].fontSize}px` : "inherit"};
 
   &:hover {
     color: var(--current-color);

--- a/packages/design-system/src/Link/index.tsx
+++ b/packages/design-system/src/Link/index.tsx
@@ -6,10 +6,12 @@ export interface LinkProps extends CommonComponentProps {
   children: string | ReactFragment;
   to: string;
   isPrimary?: boolean;
+  // allow any number of other arguments (classes, styles, etc)
   [x: string]: any;
 }
 
 const StyledLink = styled.a<{ isPrimary?: boolean }>`
+  // explicitly set color instead of relying on css current color property
   --current-color: ${(props) =>
     props.isPrimary
       ? "var(--ads-color-primary)"
@@ -23,10 +25,12 @@ const StyledLink = styled.a<{ isPrimary?: boolean }>`
     border-bottom: 1px solid var(--current-color);
   }
 
+  // hide outline for mouse, touch, or stylus usage
   &:focus {
     outline: none;
   }
 
+  // only show outline when element is accessed via keyboard
   &:focus-visible {
     color: var(--current-color);
     outline: 1px solid var(--current-color);

--- a/packages/design-system/src/Link/index.tsx
+++ b/packages/design-system/src/Link/index.tsx
@@ -1,10 +1,9 @@
-import React from "react";
+import React, { ReactFragment } from "react";
 import styled from "styled-components";
-import Text, { TextProps, TextType } from "Text";
 import { CommonComponentProps } from "Types/common";
 
-export interface LinkProps {
-  children: string;
+export interface LinkProps extends CommonComponentProps {
+  children: string | ReactFragment;
   to: string;
   isPrimary?: boolean;
 }
@@ -24,6 +23,10 @@ const StyledLink = styled.a<{ isPrimary?: boolean }>`
   }
 
   &:focus {
+    color: ${(props) =>
+      props.isPrimary
+        ? "var(--ads-color-primary-hover)"
+        : "var(--ads-text-color-default)"};
     outline: 1px solid
       ${(props) =>
         props.isPrimary

--- a/packages/design-system/src/Link/index.tsx
+++ b/packages/design-system/src/Link/index.tsx
@@ -10,30 +10,22 @@ export interface LinkProps extends CommonComponentProps {
 }
 
 const StyledLink = styled.a<{ isPrimary?: boolean }>`
-  color: ${(props) =>
+  --current-color: ${(props) =>
     props.isPrimary
       ? "var(--ads-color-primary)"
       : "var(--ads-text-color-default)"};
 
+  color: var(--current-color);
+
   &:hover {
-    color: ${(props) =>
-      props.isPrimary
-        ? "var(--ads-color-primary-hover)"
-        : "var(--ads-text-color-default)"};
     text-decoration: underline;
+    color: var(--current-color);
   }
 
   &:focus {
-    color: ${(props) =>
-      props.isPrimary
-        ? "var(--ads-color-primary-hover)"
-        : "var(--ads-text-color-default)"};
-    outline: 1px solid
-      ${(props) =>
-        props.isPrimary
-          ? "var(--ads-color-primary-hover)"
-          : "var(--ads-color-gray-4)"};
     text-decoration: underline;
+    color: var(--current-color);
+    outline: 1px solid var(--current-color);
   }
 `;
 

--- a/packages/design-system/src/Link/index.tsx
+++ b/packages/design-system/src/Link/index.tsx
@@ -6,6 +6,7 @@ export interface LinkProps extends CommonComponentProps {
   children: string | ReactFragment;
   to: string;
   isPrimary?: boolean;
+  [x: string]: any;
 }
 
 const StyledLink = styled.a<{ isPrimary?: boolean }>`

--- a/packages/design-system/src/Link/index.tsx
+++ b/packages/design-system/src/Link/index.tsx
@@ -18,14 +18,15 @@ const StyledLink = styled.a<{ isPrimary?: boolean }>`
   color: var(--current-color);
 
   &:hover {
-    text-decoration: underline;
     color: var(--current-color);
+    text-decoration: none;
+    border-bottom: 1px solid var(--current-color);
   }
 
   &:focus {
-    text-decoration: underline;
     color: var(--current-color);
     outline: 1px solid var(--current-color);
+    border-bottom: 1px solid var(--current-color);
   }
 `;
 

--- a/packages/design-system/src/Link/index.tsx
+++ b/packages/design-system/src/Link/index.tsx
@@ -1,0 +1,44 @@
+import React, { ReactNode } from "react";
+import styled, { css } from "styled-components";
+import Text, { TextProps, TextType } from "Text";
+import { CommonComponentProps } from "Types/common";
+
+export interface LinkProps {
+  children: string;
+  to: string;
+  isPrimary?: boolean;
+}
+
+const StyledLink = styled.a<{ isPrimary?: boolean }>`
+  color: ${(props) =>
+    props.isPrimary
+      ? "var(--ads-color-primary)"
+      : "var(--ads-text-color-default)"};
+
+  &:hover {
+    color: ${(props) =>
+      props.isPrimary
+        ? "var(--ads-color-primary-hover)"
+        : "var(--ads-text-color-default)"};
+    text-decoration: underline;
+  }
+
+  &:focus {
+    outline: 1px solid
+      ${(props) =>
+        props.isPrimary
+          ? "var(--ads-color-primary-hover)"
+          : "var(--ads-color-gray-4)"};
+    text-decoration: underline;
+  }
+`;
+
+const Link = ({ children, isPrimary, to }: LinkProps) => {
+  return (
+    <StyledLink href={to} isPrimary={isPrimary}>
+      {children}
+    </StyledLink>
+  );
+};
+
+export default Link;

--- a/packages/design-system/src/ListSegmentHeader/index.tsx
+++ b/packages/design-system/src/ListSegmentHeader/index.tsx
@@ -9,22 +9,14 @@ const StyledSegmentHeader = styled.div`
   font-size: ${typography["u2"].fontSize}px;
   line-height: ${typography["u2"].lineHeight}px;
   letter-spacing: ${typography["u2"].letterSpacing}px;
-  color: var(--ads-old-color-gray-10);
+  color: var(--ads-color-gray-7);
   display: flex;
   align-items: center;
-`;
-
-const StyledHr = styled.div`
-  flex: 1;
-  height: 1px;
-  background-color: var(--ads-old-color-gray-10);
-  margin-left: var(--ads-spaces-3);
 `;
 
 export type SegmentHeaderProps = {
   title: string;
   style?: CSSProperties;
-  hideStyledHr?: boolean;
 };
 
 export default function SegmentHeader(props: SegmentHeaderProps) {
@@ -34,9 +26,9 @@ export default function SegmentHeader(props: SegmentHeaderProps) {
       style={props.style}
     >
       {props.title}
-      {!props.hideStyledHr && (
-        <StyledHr data-testid={"t--styled-segment-header-hr"} />
-      )}
+      {/*  TODO: Fix cypress here */}
+      {/*          <StyledHr data-testid={"t--styled-segment-header-hr"} />
+       */}
     </StyledSegmentHeader>
   );
 }

--- a/packages/design-system/src/Radio/index.tsx
+++ b/packages/design-system/src/Radio/index.tsx
@@ -56,7 +56,10 @@ export const Radio = styled.label<{
   font-weight: ${typography.p1.fontWeight};
   line-height: ${typography.p1.lineHeight}px;
   letter-spacing: ${typography.p1.letterSpacing}px;
-  color: var(--ads-radio-default-text-color);
+  color: ${(props) =>
+    props.disabled
+      ? "var(--ads-radio-disabled-text-color)"
+      : "var(--ads-radio-default-text-color"};
   ${(props) =>
     props.columns && props.columns > 0
       ? `
@@ -98,6 +101,7 @@ export const Radio = styled.label<{
 
   input:disabled ~ .checkbox:after {
     background-color: var(--ads-radio-disabled-background-color);
+    //border: var(--ads-radio-disabled-border-color);
   }
 
   .checkbox:after {

--- a/packages/design-system/src/SearchComponent/index.tsx
+++ b/packages/design-system/src/SearchComponent/index.tsx
@@ -52,7 +52,7 @@ const SearchInputWrapper = styled(InputGroup)`
       border-radius: 0;
       box-shadow: none;
       font-size: 12px;
-      color: var(--ads-old-color-gray-10);
+      color: var(--ads-color-gray-7);
       padding-right: 20px;
       text-overflow: ellipsis;
       width: 100%;
@@ -69,7 +69,7 @@ const SearchInputWrapper = styled(InputGroup)`
     ${HideDefaultSearchCancelIcon}
     svg {
       path {
-        fill: var(--ads-old-color-gray-7);
+        fill: var(--ads-color-gray-5);
       }
     }
   }

--- a/packages/design-system/src/Switch/index.tsx
+++ b/packages/design-system/src/Switch/index.tsx
@@ -5,7 +5,7 @@ import { replayHighlightClass } from "Constants/classes";
 
 const StyledSwitch = styled(Switch)`
   &&&&& input:checked ~ span {
-    background: var(--ads-old-color-gray-10);
+    background: var(--ads-color-gray-9);
   }
 
   & input:focus + .bp3-control-indicator {

--- a/packages/design-system/src/Table/Table.stories.tsx
+++ b/packages/design-system/src/Table/Table.stories.tsx
@@ -57,3 +57,5 @@ TableExample.args = {
   columns: columns,
   data: data,
 };
+
+// TODO: Write a story using icons

--- a/packages/design-system/src/Tabs/Tabs.stories.tsx
+++ b/packages/design-system/src/Tabs/Tabs.stories.tsx
@@ -30,6 +30,7 @@ Tabs.args = {
       key: "tab1",
       title: "Tab 1",
       panelComponent: <PanelComponent title={"Tab 1"} />,
+      count: 4,
     },
     {
       key: "tab2",

--- a/packages/design-system/src/TagInput/TagInput.stories.tsx
+++ b/packages/design-system/src/TagInput/TagInput.stories.tsx
@@ -34,4 +34,11 @@ TagIpt.args = {
   label: "Emails",
   placeholder: "Enter email address",
   type: "email",
+  suggestions: [
+    {
+      id: "ksghd",
+      name: "Albin",
+    },
+  ],
+  // { id: string; name: string; icon?: string }[];
 };

--- a/packages/design-system/src/TagInput/index.tsx
+++ b/packages/design-system/src/TagInput/index.tsx
@@ -54,7 +54,7 @@ const SuggestionsWrapper = styled.div`
 
   svg {
     path {
-      fill: var(--ads-old-color-gray-7);
+      fill: var(--ads-color-gray-5);
     }
   }
 

--- a/packages/design-system/src/Text/index.tsx
+++ b/packages/design-system/src/Text/index.tsx
@@ -20,6 +20,7 @@ export enum TextType {
   BUTTON_SMALL = "btnSmall",
   SIDE_HEAD = "sideHeading",
   DANGER_HEADING = "dangerHeading",
+  CARD_SUBHEADER = "cardSubheader",
 }
 
 export enum Case {

--- a/packages/design-system/src/Text/index.tsx
+++ b/packages/design-system/src/Text/index.tsx
@@ -3,6 +3,7 @@ import { CommonComponentProps } from "Types/common";
 import { TypographyKeys, typography } from "Constants/typography";
 import { Classes } from "Constants/classes";
 
+// TODO: Why does this use a different set of keys from that in the constant typography? Refactor.
 export enum TextType {
   P0 = "p0",
   P1 = "p1",

--- a/packages/design-system/src/TextInput/TextInput.stories.tsx
+++ b/packages/design-system/src/TextInput/TextInput.stories.tsx
@@ -26,5 +26,7 @@ TextInputExample.args = {
   placeholder: "This is a Text Input placeholder",
   trimValue: false,
   useTextArea: true,
-  value: () => console.log("This is the value"),
+  helperText: "Some text",
+  value: "some text in the thing",
+  readOnly: true,
 };

--- a/packages/design-system/src/TreeDropdown/index.tsx
+++ b/packages/design-system/src/TreeDropdown/index.tsx
@@ -120,9 +120,9 @@ export const StyledMenu = styled(Menu)`
 
     &:hover:not(.t--apiFormDeleteBtn) {
       background-color: var(--ads-old-color-gallery-2);
-      color: var(--ads-old-color-gray-10);
+      color: var(--ads-color-gray-9);
       .${Classes.ICON} > svg:not([fill]) {
-        fill: var(--ads-old-color-gray-10);
+        fill: var(--ads-old-color-gray-9);
       }
     }
 

--- a/packages/design-system/src/constants/typography.ts
+++ b/packages/design-system/src/constants/typography.ts
@@ -1,3 +1,4 @@
+// TODO: Why is the constant typography different from the constant TextType in Text? Refactor.
 export const typography = {
   h1: {
     fontSize: 20,

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -93,6 +93,9 @@ export * from "./JSToggleButton";
 export { default as LabelWithTooltip } from "./LabelWithTooltip";
 export * from "./LabelWithTooltip";
 
+export { default as Link } from "./Link";
+export * from "./Link";
+
 export { default as Menu } from "./Menu";
 export * from "./Menu";
 

--- a/packages/design-system/src/themes/default/colors.css
+++ b/packages/design-system/src/themes/default/colors.css
@@ -35,6 +35,20 @@
   --ads-color-black-0 : #FFFFFF;
 
 
+  /* gray */
+  --ads-color-white: #FFFFFF;
+  --ads-color-gray-0: #F8FAFC;
+  --ads-color-gray-1: #F1F5F9;
+  --ads-color-gray-2: #E3E8EF;
+  --ads-color-gray-3: #CDD5DF;
+  --ads-color-gray-4: #99A4B3;
+  --ads-color-gray-5: #6A7585;
+  --ads-color-gray-6: #4C5664;
+  --ads-color-gray-7: #364252;
+  --ads-color-gray-8: #202939;
+  --ads-color-gray-9: #12192B;
+
+
   --ads-color-blue-150 : #6A86CE;
 
   /* green */
@@ -53,13 +67,9 @@
 
   /*  Old colors */
   /* TODO: These should go away or be renamed when the more comprehensive color palate is here */
-  --ads-old-color-gray-7: #858282;
-  --ads-old-color-gray-10: #090707;
 
   --ads-old-color-fern-green: #50AF6C;
   --ads-old-color-jagged-ice: #CAECDC;
-  --ads-old-color-blue-gray : #43464a;
-  --ads-old-color-outer-space: #363E44;
 
   --ads-old-color-hot-cinnamon: #DC5B21;
   --ads-old-color-rock-spray: #BF4109;
@@ -77,7 +87,6 @@
   --ads-old-color-champagne: #FBEED0;
 
   --ads-old-color-early-dawn: #FFFAE9;
-  --ads-old-color-dove-gray: #6D6D6D;
   --ads-old-color-pomegranate: #F22B2B;
   --ads-old-color-milano-red: #B90707;
 
@@ -86,35 +95,25 @@
   --ads-old-color-fair-pink: #FFE9E9;
   --ads-old-color-pale-blue: #E8F5FA;
 
-  --ads-old-color-mid-gray: #606065;
   --ads-old-color-gallery: #EDEDED;
   --ads-old-color-linen: #FDFAF2;
   --ads-old-color-buddha-gold: #D2A500;
 
-  --ads-old-color-alto: #D4D4D4;
   --ads-old-color-gallery-2: #EBEBEB;
-  --ads-old-color-mercury: #E8E8E8;
-  --ads-old-color-pure-black: #000000;
 
   --ads-old-color-burning-orange: #FF7742;
   --ads-old-color-curious-blue: #1D9BD1;
-  --ads-old-color-dove-gray-2: #716E6E;
   --ads-old-color-pigeon-post: #AEBAD9;
 
   --ads-old-color-royal-blue: #457AE6;
-  --ads-old-color-silver: #C4C4C4;
-  --ads-old-color-dove-gray-3: #6F6F6F;
   --ads-old-color-crusta: #F86A2B;
 
-  --ads-old-color-black-pearl: #040627;
   --ads-old-color-cornflower-blue: #6871EF;
   --ads-old-color-jaffa: #F2994A;
   --ads-old-color-enterprise-dark: #00407D;
 
   /* Colors with opacity */
   --ads-old-color-black-750-opacity-50: #4b484880;
-  --ads-old-color-alto-opacity-50: #D4D4D480;
-  --ads-old-color-white-opacity-50: #FFFFFF80;
   --ads-old-color-gray-10-opacity-50: #09070780;
   --ads-old-color-danger-red-opacity-80: #e22c2c14;
   --ads-old-color-warning-opacity-80: #e0b30e14;

--- a/packages/design-system/src/themes/default/index.css
+++ b/packages/design-system/src/themes/default/index.css
@@ -23,24 +23,21 @@
   *
   */
 
-  /** API Pane */
-  --ads-api-pane-settings-text-color: var(--ads-old-color-gray-10);
-
   /** AppIcon  */
   --ads-app-icon-normal-color: var(--ads-color-black-550);
   --ads-app-icon-background-color: var(--ads-color-black-25);
 
   /* Breadcrumbs */
-  --ads-breadcrumbs-list-text-color: var(--ads-old-color-dove-gray);
-  --ads-breadcrumbs-separator-text-color: var(--ads-old-color-dove-gray);
+  --ads-breadcrumbs-list-text-color: var(--ads-color-gray-7);
+  --ads-breadcrumbs-separator-text-color: var(--ads-color-gray-5);
   --ads-breadcrumbs-active-text-color: var(--ads-color-black-900);
 
   /** Button Tab */
-  --ads-button-tab-selected-border-color: var(--ads-old-color-gray-10);
+  --ads-button-tab-selected-border-color: var(--ads-color-gray-8);
   --ads-button-tab-border-color: var(--ads-color-black-250);
   --ads-button-tab-focus-background-color: var(--ads-old-color-gallery-2);
   --ads-button-tab-hover-background-color: var(--ads-old-color-gallery-2);
-  --ads-button-tab-svg-path-fill-color: var(--ads-old-color-gray-7);
+  --ads-button-tab-svg-path-fill-color: var(--ads-color-gray-5);
 
   /** Callout */
   --ads-callout-info-text-color: #D44100;
@@ -58,7 +55,8 @@
   --ads-checkbox-default-unchecked-border-color: #404040;
   --ads-checkbox-after-disabled-checked-border-color: #939090;
   --ads-checkbox-after-default-checked-border-color: var(--ads-color-black-0);
-  --ads-checkbox-label-text-color: var(--ads-old-color-alto);
+  --ads-checkbox-label-text-color: var(--ads-color-gray-5);
+  --ads-checkbox-label-first-child-text-color: var(--ads-color-gray-7);
 
   /** ColorSelector */
   --ads-color-selector-shadow-color: #E8E8E8;
@@ -76,20 +74,20 @@
 
   /** Dropdown */
   --ads-dropdown-hover-background-color : var(--ads-old-color-gallery-2);
-  --ads-dropdown-selected-text-color: var(--ads-old-color-gray-10);
+  --ads-dropdown-selected-text-color: var(--ads-color-gray-9);
   --ads-dropdown-disabled-header-text-color: #9F9F9F;
   --ads-dropdown-disabled-header-background-color: var(--ads-color-black-0);
   --ads-dropdown-default-header-text-color: var(--ads-color-black-750);
-  --ads-dropdown-selected-header-text-color: var(--ads-old-color-gray-10);
+  --ads-dropdown-selected-header-text-color: var(--ads-color-gray-9);
   --ads-dropdown-default-menu-border-color: var(--ads-color-black-100);
-  --ads-dropdown-default-menu-subtext-text-color: var(--ads-old-color-gray-7);
+  --ads-dropdown-default-menu-subtext-text-color: var(--ads-color-gray-7);
   --ads-dropdown-selected-menu-subtext-text-color: var(--ads-color-black-550);
   --ads-dropdown-default-menu-text-color: var(--ads-color-black-750);
-  --ads-dropdown-default-menu-hover-text-color: var(--ads-old-color-gray-10);
+  --ads-dropdown-default-menu-hover-text-color: var(--ads-color-gray-9);
   --ads-dropdown-default-menu-hover-background-color: var(--ads-color-black-200);
   --ads-dropdown-default-icon-fill-color: var(--ads-color-black-550);
   --ads-dropdown-default-icon-background-color: var(--ads-color-black-250);
-  --ads-dropdown-default-icon-selected-fill-color: var(--ads-old-color-gray-7);
+  --ads-dropdown-default-icon-selected-fill-color: var(--ads-color-gray-5);
   --ads-dropdown-default-icon-hover: var(--ads-color-black-0);
   --ads-dropdown-default-dropdown-trigger-border-color: var(--ads-color-black-900);
   --ads-dropdown-default-close-hover-background-color : var(--ads-old-color-gallery-2);
@@ -101,20 +99,20 @@
   --ads-editable-text-subcomponent-default-text-color: var(--ads-color-black-750);
 
   /** EditableTextWrapper */
-  --ads-editable-text-wrapper-default-text-color: var(--ads-old-color-alto);
+  --ads-editable-text-wrapper-default-text-color: var(--ads-color-gray-7);
 
   /** Emoji Reactions */
   --ads-emoji-reactions-bubble-background-color: var(--ads-color-black-75);
   --ads-emoji-reactions-bubble-active-background-color: var(--ads-old-color-bridesmaid);
   --ads-emoji-reactions-bubble-active-border-color: var(--ads-old-color-rock-spray);
   --ads-emoji-reactions-bubble-hover-background-color: var(--ads-old-color-gallery-2);
-  --ads-emoji-reactions-count-text-color: var(--ads-old-color-dove-gray);
+  --ads-emoji-reactions-count-text-color: var(--ads-color-gray-7);
   --ads-emoji-reactions-count-active-text-color: var(--ads-old-color-rock-spray);
   --ads-emoji-reactions-count-hover-text-color: var(--ads-color-black-750);
 
   /** FilePickerV2 */
   --ads-file-picker-v2-default-background-color: var(--ads-color-black-75);
-  --ads-file-picker-v2-default-text-color : var(--ads-old-color-dove-gray-2);
+  --ads-file-picker-v2-default-text-color : var(--ads-color-gray-7);
   --ads-file-picker-v2-success-text-color : var(--ads-old-color-jade);
   --ads-file-picker-v2-upload-progress-background-color: var(--ads-color-black-470);
   --ads-file-picker-v2-upload-success-background-color: var(--ads-old-color-fun-green);
@@ -139,9 +137,9 @@
   --ads-form-message-light-success-background-color: #EFFFF4;
 
   /** Gif Player */
-  --ads-gif-player-icon-path-fill-color: var(--ads-old-color-silver);
-  --ads-gif-player-icon-circle-fill-color: var(--ads-old-color-gray-10);
-  --ads-gif-player-text-color: var(--ads-old-color-dove-gray-3);
+  --ads-gif-player-icon-path-fill-color: var(--ads-color-gray-2);
+  --ads-gif-player-icon-circle-fill-color: var(--ads-color-gray-9);
+  --ads-gif-player-text-color: var(--ads-color-gray-5);
   --ads-gif-player-overlay-background-color: var(--ads-color-black-0);
 
   /** HighlightText */
@@ -161,7 +159,6 @@
 
   /** Intent Colors */
   --ads-intent-color-primary: var(--ads-old-color-jade);
-  --ads-intent-color-secondary: var(--ads-old-color-black-pearl);
   --ads-intent-color-success: var(--ads-old-color-cornflower-blue);
   --ads-intent-color-danger: var(--ads-old-color-danger-red);
   --ads-intent-color-none: var(--ads-color-black-200);
@@ -192,10 +189,10 @@
   --ads-menu-default-border-color: #404040;
 
   /** Menu Divider */
-  --ads-menu-divider-border-color: var(--ads-old-color-mercury);
+  --ads-menu-divider-border-color: var(--ads-color-gray-2);
 
   /** Multiswitch */
-  --ads-multiswitch-tab-list-background-color: var(--ads-old-color-mercury);
+  --ads-multiswitch-tab-list-background-color: var(--ads-color-gray-1);
   --ads-multiswitch-border-color: var(--ads-color-black-250);
   --ads-multiswitch-selected-background-color: var(--ads-color-black-0);
   --ads-multiswitch-tab-header-background-color: var(--ads-color-black-0);
@@ -216,9 +213,12 @@
   --ads-property-pane-default-button-text-color: #090707;
 
   /** Radio */
-  --ads-radio-default-text-color: var(--ads-old-color-gray-10);
-  --ads-radio-default-border-color: var(--ads-old-color-mercury);
-  --ads-radio-disabled-background-color: #C5C5C5;
+  /* TODO: why did it change again? Fix before committing */
+  --ads-radio-default-text-color: var(--ads-color-gray-9);
+  --ads-radio-default-border-color: var(--ads-color-gray-4);
+  --ads-radio-disabled-background-color: var(--ads-color-gray-3);
+  --ads-radio-disabled-border-color: var(--ads-color-gray-3);
+  --ads-radio-disabled-text-color: var(--ads-color-gray-4);
 
   /** Rectangular Switch */
   --ads-rectangular-switch-background-color: var(--ads-color-black-0);
@@ -230,8 +230,8 @@
 
   /** Scroll Indicator */
   --ads-scroll-indicator-light-thumb-background-color: var(--ads-old-color-black-750-opacity-50);
-  --ads-scroll-indicator-light-track-background-color: var(--ads-old-color-white-opacity-50);
-  --ads-scroll-indicator-dark-thumb-background-color: var(--ads-old-color-alto-opacity-50);
+  --ads-scroll-indicator-light-track-background-color: var(--ads-color-gray-1);
+  --ads-scroll-indicator-dark-thumb-background-color: var(--ads-color-gray-2);
   --ads-scroll-indicator-dark-track-background-color: var(--ads-old-color-gray-10-opacity-50);
 
   /** Search Input */
@@ -264,10 +264,10 @@
   --ads-table-table-header-hover-icon-path-color: var(--ads-color-black-850);
   --ads-table-table-row-first-table-data-default-text-color: var(--ads-color-black-850);
   --ads-table-table-row-table-data-default-text-color: var(--ads-color-black-550);
-  --ads-table-table-row-table-data-border-bottom-color: var(--ads-old-color-mercury);
+  --ads-table-table-row-table-data-border-bottom-color: var(--ads-color-gray-2);
   --ads-table-table-row-hover-background-color : var(--ads-color-black-75);
-  --ads-table-table-row-hover-icon-path-color: var(--ads-old-color-gray-10);
-  --ads-table-table-row-first-table-data-hover-text-color: var(--ads-old-color-gray-10);
+  --ads-table-table-row-hover-icon-path-color: var(--ads-color-gray-5);
+  --ads-table-table-row-first-table-data-hover-text-color: var(--ads-color-gray-9);
   --ads-table-table-row-table-data-hover-text-color: var(--ads-color-black-850);
 
   /** TableDropdown  */
@@ -276,18 +276,18 @@
   --ads-table-dropdown-selected-hover-text-color: var(--ads-color-black-850);
 
   /** Tabs */
-  --ads-tabs-default-tab-list-text-color: var(--ads-old-color-gray-7);
+  --ads-tabs-default-tab-list-text-color: var(--ads-color-gray-5);
   --ads-tabs-default-tab-list-svg-fill-color: var(--ads-color-black-0);
-  --ads-tabs-default-tab-list-response-viewer-background-color: var(--ads-old-color-mercury);
+  --ads-tabs-default-tab-list-response-viewer-background-color: var(--ads-color-gray-0);
   --ads-tabs-default-tab-focus-response-viewer-border-color: var(--ads-color-black-250);
   --ads-tabs-tab-selected-svg-fill-color: var(--ads-color-black-750);
   --ads-tabs-tab-selected-response-viewer-background-color: var(--ads-color-black-0);
   --ads-tabs-tab-selected-response-viewer-border-color: var(--ads-color-black-250);
   --ads-tabs-tab-title-response-viewer-text-color: var(--ads-primary-text-color);
-  --ads-tabs-count-background-color: var(--ads-old-color-mercury);
-  --ads-tabs-title-wrapper-text-color: var(--ads-old-color-gray-7);
+  --ads-tabs-count-background-color: var(--ads-color-gray-2);
+  --ads-tabs-title-wrapper-text-color: var(--ads-color-gray-5);
   --ads-tabs-title-wrapper-hover-text-color: var(--ads-color-black-750);
-  --ads-tabs-title-wrapper-icon-fill-color: var(--ads-old-color-gray-7);
+  --ads-tabs-title-wrapper-icon-fill-color: var(--ads-color-gray-5);
 
   /** Tab Item Background fill */
   --ads-tab-item-text-color: var(--ads-primary-text-color);
@@ -298,7 +298,7 @@
   --ads-tag-input-background-color: var(--ads-color-black-0);
   --ads-tag-input-border-color: var(--ads-color-black-250);
   --ads-tag-input-text-color: var(--ads-color-black-850);
-  --ads-tag-input-placeholder-color: var(--ads-old-color-alto);
+  --ads-tag-input-placeholder-color: var(--ads-color-gray-3);
   --ads-tag-input-active-border-color: var(--ads-primary-color);
   --ads-tag-input-active-box-shadow: "none";
   --ads-tag-input-tag-text-color: var(--ads-color-black-0);
@@ -309,23 +309,23 @@
   --ads-text-heading-color: var(--ads-color-black-850);
   --ads-text-highlight-color: var(--ads-color-black-0);
 
-  /** TextInput */
-  --ads-text-input-text-box-default-background-color: #ffffff;
-  --ads-text-input-text-box-default-text-color: #090707;
-  --ads-text-input-text-box-default-border-color: #E0DEDE;
-  --ads-text-input-text-box-disabled-background-color: #F0F0F0;
-  --ads-text-input-text-box-disabled-text-color: #6D6D6D;
-  --ads-text-input-text-box-disabled-border-color: #F0F0F0;
-  --ads-text-input-text-box-read-only-background-color: #F0F0F0;
-  --ads-text-input-text-box-read-only-text-color: #716E6E;
-  --ads-text-input-text-box-read-only-border-color: #F0F0F0;
-  --ads-text-input-text-box-hover-background-color: #FAFAFA;
-  --ads-text-input-icon-path-color: #716E6E;
-  --ads-text-input-placeholder-text-color: #A9A7A7;
-  --ads-text-input-helper-text-text-color: #858282;
+  /* TextInput */
+  --ads-text-input-text-box-default-background-color: var(--ads-color-black-0);
+  --ads-text-input-text-box-default-text-color: var(--ads-color-gray-7);
+  --ads-text-input-text-box-default-border-color: var(--ads-color-black-250);
+  --ads-text-input-text-box-disabled-background-color: var(--ads-color-gray-2);
+  --ads-text-input-text-box-disabled-text-color: var(--ads-color-gray-5);
+  --ads-text-input-text-box-disabled-border-color: var(--ads-color-gray-2);
+  --ads-text-input-text-box-read-only-background-color: var(--ads-color-gray-2);
+  --ads-text-input-text-box-read-only-text-color: var(--ads-color-gray-7);
+  --ads-text-input-text-box-read-only-border-color: var(--ads-color-gray-2);
+  --ads-text-input-text-box-hover-background-color: var(--ads-color-black-5);
+  --ads-text-input-icon-path-color: var(--ads-color-gray-5);
+  --ads-text-input-placeholder-text-color: var(--ads-color-black-450);
+  --ads-text-input-helper-text-text-color: var(--ads-color-gray-5);
 
   /* Toast */
-  --ads-toast-background-color: var(--ads-old-color-gray-10);
+  --ads-toast-background-color: var(--ads-color-gray-9);
   --ads-toast-icon-fill-color: #DCAD00;
   --ads-toast-icon-outline-color: var(--ads-old-color-pomegranate);
   --ads-toast-text-color: var(--ads-color-black-25);
@@ -334,7 +334,7 @@
 
   /* Toggle */
   --ads-toggle-slider-background-color: var(--ads-color-black-250);
-  --ads-toggle-slider-loading-background-color: var(--ads-old-color-mercury);
+  --ads-toggle-slider-loading-background-color: var(--ads-color-black-250);
   --ads-toggle-slider-disabled-on-background-color: var(--ads-color-black-0);
   --ads-toggle-slider-disabled-off-background-color: var(--ads-color-black-0);
   --ads-toggle-on-background-color: var(--ads-color-orange-500);

--- a/packages/design-system/src/themes/default/index.css
+++ b/packages/design-system/src/themes/default/index.css
@@ -1,5 +1,6 @@
 @import "colors.css";
 @import "variables.css";
+@import "themables.css";
 
 :root {
   --ads-primary-color: var(--ads-color-orange-500);
@@ -8,7 +9,7 @@
   --ads-border-radius: 0px;
   --ads-border-color: var(--ads-color-black-250);
   --ads-border-color-focus: var(--ads-color-black-900);
-  
+
 
   /** Naming convention for tokens
   *

--- a/packages/design-system/src/themes/default/themables.css
+++ b/packages/design-system/src/themes/default/themables.css
@@ -1,0 +1,5 @@
+:root {
+  --ads-text-color-default: var(--ads-color-gray-7);
+  --ads-color-primary: var(--ads-color-orange-500);
+  --ads-color-primary-hover: var(--ads-color-orange-800);
+}


### PR DESCRIPTION
## Description

Fixes issues with https://github.com/appsmithorg/appsmith/pull/17740
- underline no longer breaks for descenders
- focus styles are only activated when the element is accessed via keyboard 
- Link now explicitly accepts a type (and uses it to set font size)
- more comments on Link! explaining some css decisions. Always a good thing. 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- on the storybook
- on the main app via yalc 
- on the main app via alpha release

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
