### PR TITLE
fix: multiple on change trigger in radio component

### DIFF
--- a/.changeset/five-gorillas-chew.md
+++ b/.changeset/five-gorillas-chew.md
@@ -1,0 +1,5 @@
+---
+"@appsmithorg/design-system": patch
+---
+
+fix: multiple on change trigger in radio component

--- a/packages/design-system/src/Radio/index.tsx
+++ b/packages/design-system/src/Radio/index.tsx
@@ -143,7 +143,6 @@ export default function RadioComponent(props: RadioProps) {
       className={props.className}
       columns={props.columns}
       data-cy={props.cypressSelector}
-      onChange={onChangeHandler}
       rows={props.rows}
     >
       {props.options.map((option: OptionProps, index: number) => (
@@ -160,7 +159,7 @@ export default function RadioComponent(props: RadioProps) {
               checked={selected === option.value}
               disabled={props.disabled || option.disabled}
               name={props.name || "radio"}
-              onChange={(e) => onSelect && onSelect(e.target.value)}
+              onChange={onChangeHandler}
               type="radio"
               value={option.value}
             />


### PR DESCRIPTION
## Description

Fixed triggering radio button on change event twice.

Fixes [#18026](https://github.com/appsmithorg/appsmith/issues/18026)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Tested in storybook

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
