### PR TITLE
fix: added classname to leftElement

### DIFF
--- a/.changeset/tiny-parents-jump.md
+++ b/.changeset/tiny-parents-jump.md
@@ -2,4 +2,4 @@
 "@appsmithorg/design-system": patch
 ---
 
-fix: added classname to leftElement
+fix: added classname to leftElement in Dropdown

--- a/.changeset/tiny-parents-jump.md
+++ b/.changeset/tiny-parents-jump.md
@@ -1,0 +1,5 @@
+---
+"@appsmithorg/design-system": patch
+---
+
+fix: added classname to leftElement

--- a/packages/design-system/src/Dropdown/index.tsx
+++ b/packages/design-system/src/Dropdown/index.tsx
@@ -766,7 +766,9 @@ function DefaultDropDownValueNode({
               />
             ) : null}
             {selected?.leftElement && (
-              <LeftIconWrapper>{selected.leftElement}</LeftIconWrapper>
+              <LeftIconWrapper className="left-icon-wrapper">
+                {selected.leftElement}
+              </LeftIconWrapper>
             )}
             <Label />
             {selected?.subText && !hideSubText ? (


### PR DESCRIPTION
## Description
- Add class name to the left element of the dropdown component

Fixes # (issue)

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Tested on Storybook

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
