### PR TITLE
fix: Text input not triggering validation on defaultValue change

### DIFF
--- a/.changeset/beige-bags-act.md
+++ b/.changeset/beige-bags-act.md
@@ -1,5 +1,0 @@
----
-"@appsmithorg/design-system": patch
----
-
-fix: Flag font issue in dropdown fixed.

--- a/.changeset/clever-shoes-repeat.md
+++ b/.changeset/clever-shoes-repeat.md
@@ -1,5 +1,0 @@
----
-"@appsmithorg/design-system": patch
----
-
-chore: Updating the logic for suggestions in the tag input component

--- a/.changeset/green-ravens-sip.md
+++ b/.changeset/green-ravens-sip.md
@@ -1,5 +1,0 @@
----
-"@appsmithorg/design-system": patch
----
-
-feat: update button states - tertiary becomes secondary and we have a new, more subtle, tertiary 

--- a/.changeset/heavy-wolves-sin.md
+++ b/.changeset/heavy-wolves-sin.md
@@ -1,0 +1,5 @@
+---
+"@appsmithorg/design-system": patch
+---
+
+fix: Text input not triggering validation on defaultValue change

--- a/.changeset/mighty-pants-grow.md
+++ b/.changeset/mighty-pants-grow.md
@@ -1,5 +1,0 @@
----
-"@appsmithorg/design-system": patch
----
-
-chore: update dependency categorization

--- a/packages/design-system/CHANGELOG.md
+++ b/packages/design-system/CHANGELOG.md
@@ -1,5 +1,25 @@
 # @appsmithorg/design-system
 
+## 1.0.37
+
+### Patch Changes
+
+- [#261](https://github.com/appsmithorg/design-system/pull/261) [`0c9351f`](https://github.com/appsmithorg/design-system/commit/0c9351f7305e1a1d95eeafc4cd35cc01508ae59b) Thanks [@tanvibhakta](https://github.com/tanvibhakta)! - chore: update dependency categorization
+
+## 1.0.36
+
+### Patch Changes
+
+- [#267](https://github.com/appsmithorg/design-system/pull/267) [`56770ed`](https://github.com/appsmithorg/design-system/commit/56770ed5033462b7c2c2e3a46ee7fc67305be3c8) Thanks [@yaldram](https://github.com/yaldram)! - fix: Flag font issue in dropdown fixed.
+
+## 1.0.35
+
+### Patch Changes
+
+- [#250](https://github.com/appsmithorg/design-system/pull/250) [`12415dc`](https://github.com/appsmithorg/design-system/commit/12415dc0091cf279810afb986412fca3eeba712f) Thanks [@ankitakinger](https://github.com/ankitakinger)! - chore: Updating the logic for suggestions in the tag input component
+
+* [#255](https://github.com/appsmithorg/design-system/pull/255) [`097dbd1`](https://github.com/appsmithorg/design-system/commit/097dbd10e9ca2934a673c0ec1a2c1fcc5455172b) Thanks [@tanvibhakta](https://github.com/tanvibhakta)! - feat: update button states - tertiary becomes secondary and we have a new, more subtle, tertiary
+
 ## 1.0.34
 
 ### Patch Changes

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@appsmithorg/design-system",
-  "version": "1.0.34",
+  "version": "1.0.37",
   "description": "This is the package for the Appsmith design system components",
   "module": "build/index.js",
   "types": "build/index.d.ts",

--- a/packages/design-system/src/TextInput/index.tsx
+++ b/packages/design-system/src/TextInput/index.tsx
@@ -329,9 +329,18 @@ const TextInput = forwardRef(
       if (props.defaultValue) {
         const inputValue = props.defaultValue;
         setInputValue(inputValue);
+        checkValidator(inputValue);
         props.onChange && props.onChange(inputValue);
       }
     }, [props.defaultValue]);
+
+    const checkValidator = (inputValue: string) => {
+      const inputValueValidation =
+        props.validator && props.validator(inputValue);
+      if (inputValueValidation) {
+        props.validator && setValidation(inputValueValidation);
+      }
+    };
 
     const memoizedChangeHandler = useCallback(
       (el) => {
@@ -339,12 +348,7 @@ const TextInput = forwardRef(
           ? el.target.value.trim()
           : el.target.value;
         setInputValue(inputValue);
-        const inputValueValidation =
-          props.validator && props.validator(inputValue);
-        if (inputValueValidation) {
-          props.validator && setValidation(inputValueValidation);
-        }
-
+        checkValidator(inputValue);
         return props.onChange && props.onChange(inputValue);
       },
       [props.onChange, setValidation, trimValue],


### PR DESCRIPTION
## Description

Text Input component was not triggering validator function when the defaultValue is updated by props. This PR fixes the same.

Fixes [#17393](https://github.com/appsmithorg/appsmith/issues/17393)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Tested in local using yalc

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
