### PR TITLE
chore: Adding new icons for using them on the audit logs page for Granular Access Control

### DIFF
--- a/.changeset/friendly-dots-yell.md
+++ b/.changeset/friendly-dots-yell.md
@@ -1,0 +1,5 @@
+---
+"@appsmithorg/design-system": patch
+---
+
+chore: Adding new icons for using them on the audit logs page for Granular Access Control

--- a/packages/design-system/src/Button/index.tsx
+++ b/packages/design-system/src/Button/index.tsx
@@ -7,7 +7,6 @@ import { Classes } from "Constants/classes";
 import Icon, { IconName, IconSize } from "Icon";
 import Spinner from "Spinner";
 import { typography } from "Constants/typography";
-import { hexToRgba } from "Utils/colors";
 
 const smallButton = css`
   font-size: ${typography.btnSmall.fontSize}px;

--- a/packages/design-system/src/Icon/index.tsx
+++ b/packages/design-system/src/Icon/index.tsx
@@ -171,6 +171,10 @@ import AlertLineIcon from "remixicon-react/AlertLineIcon";
 import SettingsLineIcon from "remixicon-react/SettingsLineIcon";
 import LockUnlockLineIcon from "remixicon-react/LockUnlockLineIcon";
 import PantoneLineIcon from "remixicon-react/PantoneLineIcon";
+import UserSharedLineIcon from "remixicon-react/UserSharedLineIcon";
+import UserReceived2LineIcon from "remixicon-react/UserReceived2LineIcon";
+import UserAddLineIcon from "remixicon-react/UserAddLineIcon";
+import UserUnfollowLineIcon from "remixicon-react/UserUnfollowLineIcon";
 
 export enum IconSize {
   XXS = "extraExtraSmall",
@@ -345,8 +349,12 @@ const ICON_LOOKUP = {
   "user-2": <UserV2Icon />,
   "user-2-line": <User2LineIcon />,
   "user-3-line": <User3LineIcon />,
+  "user-add-line": <UserAddLineIcon />,
   "user-follow-line": <UserFollowLineIcon />,
   "user-heart-line": <UserHeartLineIcon />,
+  "user-received-2-line": <UserReceived2LineIcon />,
+  "user-shared-line": <UserSharedLineIcon />,
+  "user-unfollow-line": <UserUnfollowLineIcon />,
   "view-all": <RightArrowIcon />,
   "view-less": <LeftArrowIcon />,
   "warning-line": <WarningLineIcon />,


### PR DESCRIPTION
## Description

> Adding new icons for using them on the audit logs page for Granular Access Control

Fixes [#18487](https://github.com/appsmithorg/appsmith/issues/18487)

## Type of change

- Addition of icons

## How Has This Been Tested?

> Checked locally on storybook

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
