### PR TITLE
chore: Add delete row icon for Access control upgrade page

### DIFF
--- a/.changeset/twenty-owls-perform.md
+++ b/.changeset/twenty-owls-perform.md
@@ -1,0 +1,5 @@
+---
+"@appsmithorg/design-system": patch
+---
+
+chore: Add delete row icon for Access control upgrade page

--- a/packages/design-system/src/Button/index.tsx
+++ b/packages/design-system/src/Button/index.tsx
@@ -542,12 +542,13 @@ function ButtonComponent(props: ButtonProps) {
 
 function LinkButtonComponent(props: ButtonProps) {
   const { className, cypressSelector, href, onClick } = props;
+  const filteredProps = _.omit(props, ["fill"]);
   return (
     <StyledLinkButton
       className={className}
       data-cy={cypressSelector}
       href={href}
-      {...props}
+      {...filteredProps}
       onClick={(e: React.MouseEvent<HTMLElement>) => onClick && onClick(e)}
     >
       {getButtonContent(props)}

--- a/packages/design-system/src/Icon/index.tsx
+++ b/packages/design-system/src/Icon/index.tsx
@@ -179,6 +179,7 @@ import UserSharedLineIcon from "remixicon-react/UserSharedLineIcon";
 import UserReceived2LineIcon from "remixicon-react/UserReceived2LineIcon";
 import UserAddLineIcon from "remixicon-react/UserAddLineIcon";
 import UserUnfollowLineIcon from "remixicon-react/UserUnfollowLineIcon";
+import DeleteRowIcon from "remixicon-react/DeleteRowIcon";
 
 export enum IconSize {
   XXS = "extraExtraSmall",
@@ -289,6 +290,7 @@ const ICON_LOOKUP = {
   "context-menu": <ContextMenuIcon />,
   "database-2-line": <Database2Line />,
   "delete-blank": <DeleteBin7 />,
+  "delete-row": <DeleteRowIcon />,
   "double-arrow-right": <DoubleArrowRightIcon />,
   "down-arrow": <DownArrowIcon />,
   "down-arrow-2": <ArrowDownLineIcon />,


### PR DESCRIPTION
## Description

> Adding delete row icon for Access control upgrade page

Fixes [#19072](https://github.com/appsmithorg/appsmith/issues/19072)

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

> Checked the icon locally

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
