### PR TITLE
feat: tag the latest commit with the alpha tag created

### DIFF
--- a/.changeset/beige-wombats-destroy.md
+++ b/.changeset/beige-wombats-destroy.md
@@ -1,0 +1,5 @@
+---
+"@appsmithorg/design-system": patch
+---
+
+feat: tag the latest commit with the alpha tag created

--- a/packages/design-system/alpha-release.sh
+++ b/packages/design-system/alpha-release.sh
@@ -10,3 +10,7 @@ yarn build
 
 echo "==============Yarn build=============="
 npm publish --access public --tag alpha
+
+echo "==============Tag alpha on git =============="
+tag=$(npm dist-tag | grep "alpha" | awk '{print $2}')
+git tag -a "$tag" -m "tag ${tag}"


### PR DESCRIPTION
The issue: With context switching, sometimes one forgets what alpha release number belongs to which commit (and therefore contains which change). This PR aims to fix that by also tagging our alpha releases. 