### PR TITLE
fix: Setting the active tab only via onSelect function, if present in props

### DIFF
--- a/.changeset/proud-lions-search.md
+++ b/.changeset/proud-lions-search.md
@@ -1,0 +1,5 @@
+---
+"@appsmithorg/design-system": patch
+---
+
+fix: Setting the active tab only via the onSelect function, if present in props

--- a/packages/design-system/src/Tabs/Tabs.stories.tsx
+++ b/packages/design-system/src/Tabs/Tabs.stories.tsx
@@ -42,8 +42,5 @@ Tabs.args = {
       panelComponent: <PanelComponent title={"Tab 3"} />,
     },
   ],
-  onSelect: (key) => {
-    // eslint-disable-next-line no-console
-    console.log(key);
-  },
+  onSelect: undefined,
 };

--- a/packages/design-system/src/Tabs/index.tsx
+++ b/packages/design-system/src/Tabs/index.tsx
@@ -390,8 +390,7 @@ export function TabComponent(
 
       <Tabs
         onSelect={(index: number) => {
-          onSelect && onSelect(index);
-          setSelectedIndex(index);
+          onSelect ? onSelect(index) : setSelectedIndex(index);
           !isExpanded && toggleCollapse();
         }}
         selectedIndex={props.selectedIndex}


### PR DESCRIPTION
## Description

> Setting the active tab only via the onSelect function using props, if present, else setting it via the component state.

Fixes [#19088](https://github.com/appsmithorg/appsmith/issues/19088)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

> Please describe the tests that you ran to verify your changes. Provide instructions, so we can reproduce.
> Please also list any relevant details for your test configuration.

- Test A
- Test B

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
