### PR TITLE
feat: update snippet button from 3ry to 2ry

### DIFF
--- a/.changeset/real-eyes-drive.md
+++ b/.changeset/real-eyes-drive.md
@@ -1,0 +1,5 @@
+---
+"@appsmithorg/design-system": patch
+---
+
+feat: update snippet button from 3ry to 2ry

--- a/packages/design-system/src/SnippetButton/index.tsx
+++ b/packages/design-system/src/SnippetButton/index.tsx
@@ -42,7 +42,7 @@ export default function SearchSnippets(props: Props) {
       position="bottom-right"
     >
       <StyledButton
-        category={Category.tertiary}
+        category={Category.secondary}
         className={`t--search-snippets ${className}`}
         icon="snippet"
         onClick={handleClick}


### PR DESCRIPTION
Some tertiary buttons were missed out when closing https://github.com/appsmithorg/appsmith/issues/18052, not sure why. This PR updates them.