### PR TITLE
fix: Removing tooltip on table header as it is not part of our design system

### DIFF
--- a/.changeset/weak-items-dress.md
+++ b/.changeset/weak-items-dress.md
@@ -1,0 +1,5 @@
+---
+"@appsmithorg/design-system": patch
+---
+
+fix: Removing tooltip on table header as it is not part of our design system

--- a/packages/design-system/src/Table/index.tsx
+++ b/packages/design-system/src/Table/index.tsx
@@ -166,7 +166,9 @@ function Table(props: TableProps) {
             <tr {...headerGroup.getHeaderGroupProps()} key={index}>
               {headerGroup.headers.map((column, index: number) => (
                 <th
-                  {...column.getHeaderProps(column.getSortByToggleProps())}
+                  {...column.getHeaderProps(
+                    column.getSortByToggleProps({ title: undefined }),
+                  )}
                   key={index}
                 >
                   {column.render("Header")}


### PR DESCRIPTION
## Description

> Removing tooltip on table header as it is not part of our design system.

Fixes [#19263](https://github.com/appsmithorg/appsmith/issues/19263)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

> Tested in storybook locally. The tooltip is not seen on hover now, as expected.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
