### PR TITLE
fix: Rollup build failure fixed for new DS

### DIFF
--- a/packages/design-system/rollup.config.mjs
+++ b/packages/design-system/rollup.config.mjs
@@ -11,7 +11,7 @@ import image from "@rollup/plugin-image";
 
 export default {
   // TODO: Figure out regex where each directory can be a separate module without having to manually add them
-  input: ["src/index.tsx"],
+  input: ["src/index.ts"],
   output: [
     {
       dir: "build",


### PR DESCRIPTION
## Description

Fixed rollup build failure because of wrong index file mentioned in roll up configuration.


## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Manual on storybook 
- Manual on main repo
- Jest
- Cypress

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
