### PR TITLE
fix: Disable SPA fallback on Vercel

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "routes": [
+    {
+      "handle": "filesystem"
+    }
+  ]
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,13 @@
 {
-  "routes": [
+  "rewrites": [
     {
-      "handle": "filesystem"
+      "source": "/",
+      "destination": "/index.html"
+    },
+    {
+      "source": "/old/",
+      "destination": "/old/index.html"
     }
-  ]
+  ],
+  "trailingSlash": true
 }


### PR DESCRIPTION
This should get the `/old` path working.
