### PR TITLE
ci: Move build configuration to this repo from Vercel UI

### DIFF
--- a/build-stories.sh
+++ b/build-stories.sh
@@ -1,18 +1,19 @@
+#!/usr/bin/env bash
 
-# Build stories for new DS components
-cd packages/design-system
+set -o errexit
+set -o xtrace
+
+cd "$(dirname "$0")"
+
+_build-storybook() {
+  yarn install --frozen-lockfile
+  yarn build-storybook --loglevel warn --quiet --disable-telemetry --output-dir "$1"
+}
+
 echo "Building stories for new DS components"
-yarn && yarn build-storybook
-# move stories to output folder
-echo "moving story to parent folder"
-mv storybook-static ../../storybook-static
+cd packages/design-system
+_build-storybook ../../storybook-static
 
-
-# Build stories for old DS components
-cd ../design-system-old
 echo "Building stories for old DS components"
-yarn && yarn build-storybook
-# move stories to output folder
-echo "moving story to parent folder"
-mv storybook-static ../../storybook-static/old
-
+cd ../design-system-old
+_build-storybook ../../storybook-static/old

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,10 @@
 {
+  "buildCommand": "./build-stories.sh",
+  "installCommand": "",
+  "outputDirectory": "storybook-static",
+  "regions": [
+    "bom1"
+  ],
   "rewrites": [
     {
       "source": "/",


### PR DESCRIPTION
A few improvements to the deployment:

1. Move build configuration from Vercel UI to the `vercel.json`, so that
   1. The code maintainers can own the build process.
   2. The build configuration is also version-controlled.
   3. Different branches can have different build commands, useful when a PR is changing the build, like we recently needed this.
2. Move deployment to `bom1` region, since that's where it'll be accessed most from. Please correct me if this assumption is incorrect, and I'll remove that configuration.
3. Updated build script to:
   1. Produce less verbose output. Vercel doesn't show build output more than the last 2000 lines. The current output means that this is useless since they are all lines about 1% done, 2% done etc. So we reduce verbosity to get more compact and useful output. Again, a branch can temporarily change this, and it'll be reflected in that branch's preview builds.
   2. Build directly to the final destination folder, instead of moving the assets after building.
   3. Use `yarn install --frozen-lockfile` instead of just `yarn`. This means that dependencies for build will be installed from `yarn.lock`, and not from `package.json`, which is the recommended method of building on CI.
