### PR TITLE
fix: text can now have components as children

### DIFF
--- a/packages/design-system/src/Text/Text.types.ts
+++ b/packages/design-system/src/Text/Text.types.ts
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { ReactNode } from "react";
 
 // TODO: replace these values with names from the typography scale
 // this will also replace the values within typography scale in style.
@@ -20,9 +20,10 @@ export type TextProps = {
   /** (try not to) pass addition classes here */
   className?: string;
   /** the words you want to display */
-  children: string;
+  children: ReactNode;
   /** style the text based on it's function */
   kind?: Kind;
 } & React.HTMLAttributes<HTMLHeadingElement> &
   React.HTMLAttributes<HTMLParagraphElement> &
-  React.HTMLAttributes<HTMLSpanElement>;
+  React.HTMLAttributes<HTMLSpanElement> &
+  React.HTMLAttributes<HTMLLabelElement>;


### PR DESCRIPTION
## Description

This PR will allow Text to be used as a label and have children that are components. This increases the place Text can be used, increasing the themability of the system. 

Depends on # (pr)

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

## How Has This Been Tested?

- Manual on storybook 
- Manual on main repo
- Jest
- Cypress

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
