### PR TITLE
fix: remove gap

### DIFF
--- a/packages/design-system/src/__theme__/default/index.css
+++ b/packages/design-system/src/__theme__/default/index.css
@@ -143,7 +143,7 @@
   */
   --ads-v2-color-outline: var(--ads-v2-color-blue-300);
   --ads-v2-border-width-outline: 2px;
-  --ads-v2-offset-outline: 1px;
+  --ads-v2-offset-outline: 0;
 
   /**
     * ===========================================*


### PR DESCRIPTION
Remove the gap between the component and the outline ring, as per https://theappsmith.slack.com/archives/C045A6F2GGG/p1675836512007859