### PR TITLE
chore: change the trigger for the workflow

### DIFF
--- a/.github/workflows/test-build-docker-image.yml
+++ b/.github/workflows/test-build-docker-image.yml
@@ -1,11 +1,14 @@
-# Workflow trigger on any push and pull request
+# Workflow trigger on any push and pull request.
+# For now this will only run on commenting /build-design-system
 name:  Test, build and push
 
 on:
-  push:
-    branches: [release, main]
-    paths:
-      - "packages/design-system/**"
+#  push:
+#    branches: [ release, main ]
+#    paths:
+#      - "packages/design-system/**"
+  issue_comment:
+    types: [ created ]
 
 # Change the working directory for all the jobs in this workflow
 defaults:


### PR DESCRIPTION
## Description

Preventing the test/build/push workflow from running on every branch because pollutes the notifications and eats into ci minutes.

## Type of change

- Chore (housekeeping or task changes that don't impact user perception)

## How Has This Been Tested?

- Manual on storybook 
- Manual on main repo
- Jest
- Cypress

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
