### PR TITLE
chore: Adding the support for row expansion on the Table component

### DIFF
--- a/.changeset/dry-bugs-attack.md
+++ b/.changeset/dry-bugs-attack.md
@@ -1,6 +1,5 @@
 ---
 "@appsmithorg/design-system-old": patch
-"@appsmithorg/design-system": patch
 ---
 
 chore: Adding the support for row expansion on the Table component

--- a/.changeset/dry-bugs-attack.md
+++ b/.changeset/dry-bugs-attack.md
@@ -1,0 +1,6 @@
+---
+"@appsmithorg/design-system-old": patch
+"@appsmithorg/design-system": patch
+---
+
+chore: Adding the support for row expansion on the Table component

--- a/packages/design-system-old/src/Table/index.tsx
+++ b/packages/design-system-old/src/Table/index.tsx
@@ -1,4 +1,4 @@
-import { useTable, useSortBy } from "react-table";
+import { useTable, useSortBy, useExpanded } from "react-table";
 import React from "react";
 import styled from "styled-components";
 import { ReactComponent as DownArrow } from "../assets/icons/ads/down_arrow.svg";
@@ -156,7 +156,7 @@ function Table(props: TableProps) {
     headerGroups,
     prepareRow,
     rows,
-  } = useTable({ columns, data }, useSortBy);
+  } = useTable({ columns, data }, useSortBy, useExpanded);
 
   return (
     <Styles>


### PR DESCRIPTION
## Description

> Adding the support for row expansion on the Table component.

Fixes [#21081](https://github.com/appsmithorg/appsmith/issues/21081)

Depends on [#1147](https://github.com/appsmithorg/appsmith-ee/pull/1147)
> every PR in the design-system repository should have a corresponding PR in the appsmith repository to ensure that changes here don't break existing flows. 
> Link the corresponding PR here to trigger pulls and prevent accidental merging.
> If relevant, link the enterprise PR here as well.

## Type of change

- Chore (housekeeping or task changes that don't impact user perception)

## How Has This Been Tested?
> This has been tested on storybook and has no effects on the table component. Only if we use the expansion property by sending subRows to the data, will the expansion feature work.

- Manual on storybook 

## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
