### PR TITLE
perf(icons): load icons on-demand

### DIFF
--- a/.changeset/chilled-pets-sin.md
+++ b/.changeset/chilled-pets-sin.md
@@ -1,0 +1,6 @@
+---
+"@appsmithorg/design-system": minor
+"@appsmithorg/design-system-old": minor
+---
+
+feat: new importSvg and importRemixIcon wrappers for code-splitting icons

--- a/packages/design-system-old/package.json
+++ b/packages/design-system-old/package.json
@@ -59,6 +59,7 @@
     "@testing-library/user-event": "13.5.0",
     "@types/emoji-mart": "3.0.4",
     "@types/jest": "27.4.1",
+    "@types/loadable__component": "^5.13.4",
     "@types/lodash-es": "^4.17.6",
     "@types/react": "^17.0.2",
     "@types/react-form": "^4.0.2",
@@ -124,7 +125,7 @@
     "tinycolor2": "^1.4.2",
     "ts-jest": "27.0.0",
     "tsconfig-paths-webpack-plugin": "^3.5.2",
-    "typescript": "4.5.5",
+    "typescript": "4.9.5",
     "wait-on": "^5.3.0"
   },
   "peerDependencies": {
@@ -132,9 +133,9 @@
     "@blueprintjs/datetime": "3.23.6",
     "copy-to-clipboard": "^3.3.1",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2",
     "react-dnd": "^9.3.4",
     "react-dnd-html5-backend": "^9.3.4",
+    "react-dom": "^17.0.2",
     "react-redux": "^7.2.4",
     "react-router-dom": "^6.3.0",
     "react-table": "^7.8.0",
@@ -166,6 +167,7 @@
     "not op_mini all"
   ],
   "dependencies": {
+    "@loadable/component": "^5.15.3",
     "emoji-mart": "3.0.1"
   }
 }

--- a/packages/design-system-old/package.json
+++ b/packages/design-system-old/package.json
@@ -167,7 +167,6 @@
     "not op_mini all"
   ],
   "dependencies": {
-    "@loadable/component": "^5.15.3",
     "emoji-mart": "3.0.1"
   }
 }

--- a/packages/design-system-old/src/AppIcon/index.tsx
+++ b/packages/design-system-old/src/AppIcon/index.tsx
@@ -2,267 +2,267 @@ import React, { useMemo } from "react";
 import styled from "styled-components";
 import { CommonComponentProps } from "Types/common";
 import { Classes } from "Constants/classes";
-import { loadableForRemixIcons, loadableForSvg } from "Utils/icon-loadables";
+import { importRemixIcon, importSvg } from "Utils/icon-loadables";
 
-const BagIcon = loadableForSvg(() =>
+const BagIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/bag.svg"),
 );
-const ProductIcon = loadableForSvg(() =>
+const ProductIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/product.svg"),
 );
-const BookIcon = loadableForSvg(() =>
+const BookIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/book.svg"),
 );
-const CameraIcon = loadableForSvg(() =>
+const CameraIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/camera.svg"),
 );
-const FileIcon = loadableForSvg(() =>
+const FileIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/file.svg"),
 );
-const ChatIcon = loadableForSvg(() =>
+const ChatIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/chat.svg"),
 );
-const CalenderIcon = loadableForSvg(() =>
+const CalenderIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/calender.svg"),
 );
-const FrameIcon = loadableForSvg(() =>
+const FrameIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/frame.svg"),
 );
-const GlobeIcon = loadableForSvg(() =>
+const GlobeIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/globe.svg"),
 );
-const ShopperIcon = loadableForSvg(() =>
+const ShopperIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/shopper.svg"),
 );
-const HeartIcon = loadableForSvg(() =>
+const HeartIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/heart.svg"),
 );
-const FlightIcon = loadableForSvg(() =>
+const FlightIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/flight.svg"),
 );
-const AlienIcon = loadableForSvg(() =>
+const AlienIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/alien.svg"),
 );
-const BarGraphIcon = loadableForSvg(() =>
+const BarGraphIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/bar-graph.svg"),
 );
-const BasketballIcon = loadableForSvg(() =>
+const BasketballIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/basketball.svg"),
 );
-const BicycleIcon = loadableForSvg(() =>
+const BicycleIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/bicycle.svg"),
 );
-const BirdIcon = loadableForSvg(() =>
+const BirdIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/bird.svg"),
 );
-const BitcoinIcon = loadableForSvg(() =>
+const BitcoinIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/bitcoin.svg"),
 );
-const BurgerIcon = loadableForSvg(() =>
+const BurgerIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/burger.svg"),
 );
-const BusIcon = loadableForSvg(() =>
+const BusIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/bus.svg"),
 );
-const AirplaneIcon = loadableForSvg(() =>
+const AirplaneIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/airplane.svg"),
 );
-const CallIcon = loadableForSvg(() =>
+const CallIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/call.svg"),
 );
-const CarIcon = loadableForSvg(() =>
+const CarIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/car.svg"),
 );
-const CardIcon = loadableForSvg(() =>
+const CardIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/card.svg"),
 );
-const CatIcon = loadableForSvg(() =>
+const CatIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/cat.svg"),
 );
-const ChineseRemnibiIcon = loadableForSvg(() =>
+const ChineseRemnibiIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/chinese-remnibi.svg"),
 );
-const CloudIcon = loadableForSvg(() =>
+const CloudIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/cloud.svg"),
 );
-const CodingIcon = loadableForSvg(() =>
+const CodingIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/coding.svg"),
 );
-const CouplesIcon = loadableForSvg(() =>
+const CouplesIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/couples.svg"),
 );
-const CricketIcon = loadableForSvg(() =>
+const CricketIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/cricket.svg"),
 );
-const DiamondIcon = loadableForSvg(() =>
+const DiamondIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/diamond.svg"),
 );
-const DogIcon = loadableForSvg(() =>
+const DogIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/dog.svg"),
 );
-const DollarIcon = loadableForSvg(() =>
+const DollarIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/dollar.svg"),
 );
-const EarthIcon = loadableForSvg(() =>
+const EarthIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/earth.svg"),
 );
-const EmailIcon = loadableForSvg(() =>
+const EmailIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/email.svg"),
 );
-const EurosIcon = loadableForSvg(() =>
+const EurosIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/euros.svg"),
 );
-const FamilyIcon = loadableForSvg(() =>
+const FamilyIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/family.svg"),
 );
-const FlagIcon = loadableForSvg(() =>
+const FlagIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/flag.svg"),
 );
-const FootballIcon = loadableForSvg(() =>
+const FootballIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/football.svg"),
 );
-const HatIcon = loadableForSvg(() =>
+const HatIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/hat.svg"),
 );
-const HeadphonesIcon = loadableForSvg(() =>
+const HeadphonesIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/headphones.svg"),
 );
-const HospitalIcon = loadableForSvg(() =>
+const HospitalIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/hospital.svg"),
 );
-const JoystickIcon = loadableForSvg(() =>
+const JoystickIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/joystick.svg"),
 );
-const LaptopIcon = loadableForSvg(() =>
+const LaptopIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/laptop.svg"),
 );
-const LineChartIcon = loadableForSvg(() =>
+const LineChartIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/line-chart.svg"),
 );
-const LocationIcon = loadableForSvg(() =>
+const LocationIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/location.svg"),
 );
-const LotusIcon = loadableForSvg(() =>
+const LotusIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/lotus.svg"),
 );
-const LoveIcon = loadableForSvg(() =>
+const LoveIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/love.svg"),
 );
-const MedalIcon = loadableForSvg(() =>
+const MedalIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/medal.svg"),
 );
-const MedicalIcon = loadableForSvg(() =>
+const MedicalIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/medical.svg"),
 );
-const MoneyIcon = loadableForSvg(() =>
+const MoneyIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/money.svg"),
 );
-const MoonIcon = loadableForSvg(() =>
+const MoonIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/moon.svg"),
 );
-const MugIcon = loadableForSvg(() =>
+const MugIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/mug.svg"),
 );
-const MusicIcon = loadableForSvg(() =>
+const MusicIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/music.svg"),
 );
-const PantsIcon = loadableForSvg(() =>
+const PantsIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/pants.svg"),
 );
-const PieChartIcon = loadableForSvg(() =>
+const PieChartIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/pie-chart.svg"),
 );
-const PizzaIcon = loadableForSvg(() =>
+const PizzaIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/pizza.svg"),
 );
-const PlantIcon = loadableForSvg(() =>
+const PlantIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/plant.svg"),
 );
-const RainyWeatherIcon = loadableForSvg(() =>
+const RainyWeatherIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/rainy-weather.svg"),
 );
-const RestaurantIcon = loadableForSvg(() =>
+const RestaurantIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/restaurant.svg"),
 );
-const RocketIcon = loadableForSvg(() =>
+const RocketIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/rocket.svg"),
 );
-const RoseIcon = loadableForSvg(() =>
+const RoseIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/rose.svg"),
 );
-const RupeeIcon = loadableForSvg(() =>
+const RupeeIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/rupee.svg"),
 );
-const SaturnIcon = loadableForSvg(() =>
+const SaturnIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/saturn.svg"),
 );
-const ServerIcon = loadableForSvg(() =>
+const ServerIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/server.svg"),
 );
-const ShakeHandsIcon = loadableForSvg(() =>
+const ShakeHandsIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/shake-hands.svg"),
 );
-const ShirtIcon = loadableForSvg(() =>
+const ShirtIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/shirt.svg"),
 );
-const ShopIcon = loadableForSvg(() =>
+const ShopIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/shop.svg"),
 );
-const SinglePersonIcon = loadableForSvg(() =>
+const SinglePersonIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/single-person.svg"),
 );
-const SmartphoneIcon = loadableForSvg(() =>
+const SmartphoneIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/smartphone.svg"),
 );
-const SnowyWeatherIcon = loadableForSvg(() =>
+const SnowyWeatherIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/snowy-weather.svg"),
 );
-const StarsIcon = loadableForSvg(() =>
+const StarsIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/stars.svg"),
 );
-const SunflowerIcon = loadableForSvg(() =>
+const SunflowerIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/sunflower.svg"),
 );
-const SystemIcon = loadableForSvg(() =>
+const SystemIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/system.svg"),
 );
-const TeamIcon = loadableForSvg(() =>
+const TeamIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/team.svg"),
 );
-const TreeIcon = loadableForSvg(() =>
+const TreeIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/tree.svg"),
 );
-const UkPoundsIcon = loadableForSvg(() =>
+const UkPoundsIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/uk-pounds.svg"),
 );
-const WebsiteIcon = loadableForSvg(() =>
+const WebsiteIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/website.svg"),
 );
-const YenIcon = loadableForSvg(() =>
+const YenIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/yen.svg"),
 );
-const SteamBowlIcon = loadableForSvg(() =>
+const SteamBowlIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/steam-bowl.svg"),
 );
-const ArrowDownIcon = loadableForRemixIcons(() =>
+const ArrowDownIcon = importRemixIcon(() =>
   import("remixicon-react/ArrowDownSLineIcon"),
 );
-const ArrowUpIcon = loadableForRemixIcons(() =>
+const ArrowUpIcon = importRemixIcon(() =>
   import("remixicon-react/ArrowUpSLineIcon"),
 );
-const ArrowLeftIcon = loadableForRemixIcons(() =>
+const ArrowLeftIcon = importRemixIcon(() =>
   import("remixicon-react/ArrowLeftSLineIcon"),
 );
-const ArrowRightIcon = loadableForRemixIcons(() =>
+const ArrowRightIcon = importRemixIcon(() =>
   import("remixicon-react/ArrowRightSLineIcon"),
 );
-const HelpIcon = loadableForRemixIcons(() =>
+const HelpIcon = importRemixIcon(() =>
   import("remixicon-react/QuestionLineIcon"),
 );
-const OpenNewTabIcon = loadableForRemixIcons(() =>
+const OpenNewTabIcon = importRemixIcon(() =>
   import("remixicon-react/ShareBoxLineIcon"),
 );
-const ServerLineIcon = loadableForRemixIcons(() =>
+const ServerLineIcon = importRemixIcon(() =>
   import("remixicon-react/ServerLineIcon"),
 );
 

--- a/packages/design-system-old/src/AppIcon/index.tsx
+++ b/packages/design-system-old/src/AppIcon/index.tsx
@@ -1,95 +1,270 @@
 import React, { useMemo } from "react";
-import { ReactComponent as BagIcon } from "../assets/icons/ads/app-icons/bag.svg";
-import { ReactComponent as ProductIcon } from "../assets/icons/ads/app-icons/product.svg";
-import { ReactComponent as BookIcon } from "../assets/icons/ads/app-icons/book.svg";
-import { ReactComponent as CameraIcon } from "../assets/icons/ads/app-icons/camera.svg";
-import { ReactComponent as FileIcon } from "../assets/icons/ads/app-icons/file.svg";
-import { ReactComponent as ChatIcon } from "../assets/icons/ads/app-icons/chat.svg";
-import { ReactComponent as CalenderIcon } from "../assets/icons/ads/app-icons/calender.svg";
-import { ReactComponent as FrameIcon } from "../assets/icons/ads/app-icons/frame.svg";
-import { ReactComponent as GlobeIcon } from "../assets/icons/ads/app-icons/globe.svg";
-import { ReactComponent as ShopperIcon } from "../assets/icons/ads/app-icons/shopper.svg";
-import { ReactComponent as HeartIcon } from "../assets/icons/ads/app-icons/heart.svg";
-import { ReactComponent as FlightIcon } from "../assets/icons/ads/app-icons/flight.svg";
-import { ReactComponent as AlienIcon } from "../assets/icons/ads/app-icons/alien.svg";
-import { ReactComponent as BarGraphIcon } from "../assets/icons/ads/app-icons/bar-graph.svg";
-import { ReactComponent as BasketballIcon } from "../assets/icons/ads/app-icons/basketball.svg";
-import { ReactComponent as BicycleIcon } from "../assets/icons/ads/app-icons/bicycle.svg";
-import { ReactComponent as BirdIcon } from "../assets/icons/ads/app-icons/bird.svg";
-import { ReactComponent as BitcoinIcon } from "../assets/icons/ads/app-icons/bitcoin.svg";
-import { ReactComponent as BurgerIcon } from "../assets/icons/ads/app-icons/burger.svg";
-import { ReactComponent as BusIcon } from "../assets/icons/ads/app-icons/bus.svg";
-import { ReactComponent as AirplaneIcon } from "../assets/icons/ads/app-icons/airplane.svg";
-import { ReactComponent as CallIcon } from "../assets/icons/ads/app-icons/call.svg";
-import { ReactComponent as CarIcon } from "../assets/icons/ads/app-icons/car.svg";
-import { ReactComponent as CardIcon } from "../assets/icons/ads/app-icons/card.svg";
-import { ReactComponent as CatIcon } from "../assets/icons/ads/app-icons/cat.svg";
-import { ReactComponent as ChineseRemnibiIcon } from "../assets/icons/ads/app-icons/chinese-remnibi.svg";
-import { ReactComponent as CloudIcon } from "../assets/icons/ads/app-icons/cloud.svg";
-import { ReactComponent as CodingIcon } from "../assets/icons/ads/app-icons/coding.svg";
-import { ReactComponent as CouplesIcon } from "../assets/icons/ads/app-icons/couples.svg";
-import { ReactComponent as CricketIcon } from "../assets/icons/ads/app-icons/cricket.svg";
-import { ReactComponent as DiamondIcon } from "../assets/icons/ads/app-icons/diamond.svg";
-import { ReactComponent as DogIcon } from "../assets/icons/ads/app-icons/dog.svg";
-import { ReactComponent as DollarIcon } from "../assets/icons/ads/app-icons/dollar.svg";
-import { ReactComponent as EarthIcon } from "../assets/icons/ads/app-icons/earth.svg";
-import { ReactComponent as EmailIcon } from "../assets/icons/ads/app-icons/email.svg";
-import { ReactComponent as EurosIcon } from "../assets/icons/ads/app-icons/euros.svg";
-import { ReactComponent as FamilyIcon } from "../assets/icons/ads/app-icons/family.svg";
-import { ReactComponent as FlagIcon } from "../assets/icons/ads/app-icons/flag.svg";
-import { ReactComponent as FootballIcon } from "../assets/icons/ads/app-icons/football.svg";
-import { ReactComponent as HatIcon } from "../assets/icons/ads/app-icons/hat.svg";
-import { ReactComponent as HeadphonesIcon } from "../assets/icons/ads/app-icons/headphones.svg";
-import { ReactComponent as HospitalIcon } from "../assets/icons/ads/app-icons/hospital.svg";
-import { ReactComponent as JoystickIcon } from "../assets/icons/ads/app-icons/joystick.svg";
-import { ReactComponent as LaptopIcon } from "../assets/icons/ads/app-icons/laptop.svg";
-import { ReactComponent as LineChartIcon } from "../assets/icons/ads/app-icons/line-chart.svg";
-import { ReactComponent as LocationIcon } from "../assets/icons/ads/app-icons/location.svg";
-import { ReactComponent as LotusIcon } from "../assets/icons/ads/app-icons/lotus.svg";
-import { ReactComponent as LoveIcon } from "../assets/icons/ads/app-icons/love.svg";
-import { ReactComponent as MedalIcon } from "../assets/icons/ads/app-icons/medal.svg";
-import { ReactComponent as MedicalIcon } from "../assets/icons/ads/app-icons/medical.svg";
-import { ReactComponent as MoneyIcon } from "../assets/icons/ads/app-icons/money.svg";
-import { ReactComponent as MoonIcon } from "../assets/icons/ads/app-icons/moon.svg";
-import { ReactComponent as MugIcon } from "../assets/icons/ads/app-icons/mug.svg";
-import { ReactComponent as MusicIcon } from "../assets/icons/ads/app-icons/music.svg";
-import { ReactComponent as PantsIcon } from "../assets/icons/ads/app-icons/pants.svg";
-import { ReactComponent as PieChartIcon } from "../assets/icons/ads/app-icons/pie-chart.svg";
-import { ReactComponent as PizzaIcon } from "../assets/icons/ads/app-icons/pizza.svg";
-import { ReactComponent as PlantIcon } from "../assets/icons/ads/app-icons/plant.svg";
-import { ReactComponent as RainyWeatherIcon } from "../assets/icons/ads/app-icons/rainy-weather.svg";
-import { ReactComponent as RestaurantIcon } from "../assets/icons/ads/app-icons/restaurant.svg";
-import { ReactComponent as RocketIcon } from "../assets/icons/ads/app-icons/rocket.svg";
-import { ReactComponent as RoseIcon } from "../assets/icons/ads/app-icons/rose.svg";
-import { ReactComponent as RupeeIcon } from "../assets/icons/ads/app-icons/rupee.svg";
-import { ReactComponent as SaturnIcon } from "../assets/icons/ads/app-icons/saturn.svg";
-import { ReactComponent as ServerIcon } from "../assets/icons/ads/app-icons/server.svg";
-import { ReactComponent as ShakeHandsIcon } from "../assets/icons/ads/app-icons/shake-hands.svg";
-import { ReactComponent as ShirtIcon } from "../assets/icons/ads/app-icons/shirt.svg";
-import { ReactComponent as ShopIcon } from "../assets/icons/ads/app-icons/shop.svg";
-import { ReactComponent as SinglePersonIcon } from "../assets/icons/ads/app-icons/single-person.svg";
-import { ReactComponent as SmartphoneIcon } from "../assets/icons/ads/app-icons/smartphone.svg";
-import { ReactComponent as SnowyWeatherIcon } from "../assets/icons/ads/app-icons/snowy-weather.svg";
-import { ReactComponent as StarsIcon } from "../assets/icons/ads/app-icons/stars.svg";
-import { ReactComponent as SunflowerIcon } from "../assets/icons/ads/app-icons/sunflower.svg";
-import { ReactComponent as SystemIcon } from "../assets/icons/ads/app-icons/system.svg";
-import { ReactComponent as TeamIcon } from "../assets/icons/ads/app-icons/team.svg";
-import { ReactComponent as TreeIcon } from "../assets/icons/ads/app-icons/tree.svg";
-import { ReactComponent as UkPoundsIcon } from "../assets/icons/ads/app-icons/uk-pounds.svg";
-import { ReactComponent as WebsiteIcon } from "../assets/icons/ads/app-icons/website.svg";
-import { ReactComponent as YenIcon } from "../assets/icons/ads/app-icons/yen.svg";
-import { ReactComponent as SteamBowlIcon } from "../assets/icons/ads/app-icons/steam-bowl.svg";
-import ArrowDownIcon from "remixicon-react/ArrowDownSLineIcon";
-import ArrowUpIcon from "remixicon-react/ArrowUpSLineIcon";
-import ArrowLeftIcon from "remixicon-react/ArrowLeftSLineIcon";
-import ArrowRightIcon from "remixicon-react/ArrowRightSLineIcon";
-import HelpIcon from "remixicon-react/QuestionLineIcon";
-import OpenNewTabIcon from "remixicon-react/ShareBoxLineIcon";
-import ServerLineIcon from "remixicon-react/ServerLineIcon";
-
 import styled from "styled-components";
 import { CommonComponentProps } from "Types/common";
 import { Classes } from "Constants/classes";
+import { loadableForRemixIcons, loadableForSvg } from "Utils/icon-loadables";
+
+const BagIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/bag.svg"),
+);
+const ProductIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/product.svg"),
+);
+const BookIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/book.svg"),
+);
+const CameraIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/camera.svg"),
+);
+const FileIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/file.svg"),
+);
+const ChatIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/chat.svg"),
+);
+const CalenderIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/calender.svg"),
+);
+const FrameIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/frame.svg"),
+);
+const GlobeIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/globe.svg"),
+);
+const ShopperIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/shopper.svg"),
+);
+const HeartIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/heart.svg"),
+);
+const FlightIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/flight.svg"),
+);
+const AlienIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/alien.svg"),
+);
+const BarGraphIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/bar-graph.svg"),
+);
+const BasketballIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/basketball.svg"),
+);
+const BicycleIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/bicycle.svg"),
+);
+const BirdIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/bird.svg"),
+);
+const BitcoinIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/bitcoin.svg"),
+);
+const BurgerIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/burger.svg"),
+);
+const BusIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/bus.svg"),
+);
+const AirplaneIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/airplane.svg"),
+);
+const CallIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/call.svg"),
+);
+const CarIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/car.svg"),
+);
+const CardIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/card.svg"),
+);
+const CatIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/cat.svg"),
+);
+const ChineseRemnibiIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/chinese-remnibi.svg"),
+);
+const CloudIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/cloud.svg"),
+);
+const CodingIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/coding.svg"),
+);
+const CouplesIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/couples.svg"),
+);
+const CricketIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/cricket.svg"),
+);
+const DiamondIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/diamond.svg"),
+);
+const DogIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/dog.svg"),
+);
+const DollarIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/dollar.svg"),
+);
+const EarthIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/earth.svg"),
+);
+const EmailIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/email.svg"),
+);
+const EurosIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/euros.svg"),
+);
+const FamilyIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/family.svg"),
+);
+const FlagIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/flag.svg"),
+);
+const FootballIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/football.svg"),
+);
+const HatIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/hat.svg"),
+);
+const HeadphonesIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/headphones.svg"),
+);
+const HospitalIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/hospital.svg"),
+);
+const JoystickIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/joystick.svg"),
+);
+const LaptopIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/laptop.svg"),
+);
+const LineChartIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/line-chart.svg"),
+);
+const LocationIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/location.svg"),
+);
+const LotusIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/lotus.svg"),
+);
+const LoveIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/love.svg"),
+);
+const MedalIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/medal.svg"),
+);
+const MedicalIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/medical.svg"),
+);
+const MoneyIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/money.svg"),
+);
+const MoonIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/moon.svg"),
+);
+const MugIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/mug.svg"),
+);
+const MusicIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/music.svg"),
+);
+const PantsIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/pants.svg"),
+);
+const PieChartIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/pie-chart.svg"),
+);
+const PizzaIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/pizza.svg"),
+);
+const PlantIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/plant.svg"),
+);
+const RainyWeatherIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/rainy-weather.svg"),
+);
+const RestaurantIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/restaurant.svg"),
+);
+const RocketIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/rocket.svg"),
+);
+const RoseIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/rose.svg"),
+);
+const RupeeIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/rupee.svg"),
+);
+const SaturnIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/saturn.svg"),
+);
+const ServerIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/server.svg"),
+);
+const ShakeHandsIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/shake-hands.svg"),
+);
+const ShirtIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/shirt.svg"),
+);
+const ShopIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/shop.svg"),
+);
+const SinglePersonIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/single-person.svg"),
+);
+const SmartphoneIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/smartphone.svg"),
+);
+const SnowyWeatherIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/snowy-weather.svg"),
+);
+const StarsIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/stars.svg"),
+);
+const SunflowerIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/sunflower.svg"),
+);
+const SystemIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/system.svg"),
+);
+const TeamIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/team.svg"),
+);
+const TreeIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/tree.svg"),
+);
+const UkPoundsIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/uk-pounds.svg"),
+);
+const WebsiteIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/website.svg"),
+);
+const YenIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/yen.svg"),
+);
+const SteamBowlIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/steam-bowl.svg"),
+);
+const ArrowDownIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/ArrowDownSLineIcon"),
+);
+const ArrowUpIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/ArrowUpSLineIcon"),
+);
+const ArrowLeftIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/ArrowLeftSLineIcon"),
+);
+const ArrowRightIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/ArrowRightSLineIcon"),
+);
+const HelpIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/QuestionLineIcon"),
+);
+const OpenNewTabIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/ShareBoxLineIcon"),
+);
+const ServerLineIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/ServerLineIcon"),
+);
 
 enum Size {
   xxs = "xxs",

--- a/packages/design-system-old/src/ColorPicker/index.tsx
+++ b/packages/design-system-old/src/ColorPicker/index.tsx
@@ -7,10 +7,16 @@ import {
   Position,
   Classes,
 } from "@blueprintjs/core";
-import { ReactComponent as CheckedIcon } from "../assets/icons/control/checkmark.svg";
-import { ReactComponent as ColorPickerIcon } from "../assets/icons/control/color-picker.svg";
 import debounce from "lodash/debounce";
 import { replayHighlightClass } from "Constants/classes";
+import { loadableForSvg } from "Utils/icon-loadables";
+
+const CheckedIcon = loadableForSvg(() =>
+  import("../assets/icons/control/checkmark.svg"),
+);
+const ColorPickerIcon = loadableForSvg(() =>
+  import("../assets/icons/control/color-picker.svg"),
+);
 
 const ColorIcon = styled.div<{ color: string }>`
   width: 24px;

--- a/packages/design-system-old/src/ColorPicker/index.tsx
+++ b/packages/design-system-old/src/ColorPicker/index.tsx
@@ -9,12 +9,12 @@ import {
 } from "@blueprintjs/core";
 import debounce from "lodash/debounce";
 import { replayHighlightClass } from "Constants/classes";
-import { loadableForSvg } from "Utils/icon-loadables";
+import { importSvg } from "Utils/icon-loadables";
 
-const CheckedIcon = loadableForSvg(() =>
+const CheckedIcon = importSvg(() =>
   import("../assets/icons/control/checkmark.svg"),
 );
-const ColorPickerIcon = loadableForSvg(() =>
+const ColorPickerIcon = importSvg(() =>
   import("../assets/icons/control/color-picker.svg"),
 );
 

--- a/packages/design-system-old/src/ControlIcons/index.tsx
+++ b/packages/design-system-old/src/ControlIcons/index.tsx
@@ -1,199 +1,181 @@
 import React, { JSXElementConstructor } from "react";
 import { IconProps, IconWrapper } from "Constants/Icon";
-import { loadableForRemixIcons, loadableForSvg } from "Utils/icon-loadables";
+import { importRemixIcon, importSvg } from "Utils/icon-loadables";
 import PlayIcon from "../assets/icons/control/play-icon.png";
 
-const DeleteIcon = loadableForSvg(() =>
+const DeleteIcon = importSvg(() =>
   import("../assets/icons/control/delete.svg"),
 );
-const MoveIcon = loadableForSvg(() =>
-  import("../assets/icons/control/move.svg"),
-);
-const EditIcon = loadableForSvg(() =>
-  import("../assets/icons/control/edit.svg"),
-);
-const ViewIcon = loadableForSvg(() =>
-  import("../assets/icons/control/view.svg"),
-);
-const MoreVerticalIcon = loadableForSvg(() =>
+const MoveIcon = importSvg(() => import("../assets/icons/control/move.svg"));
+const EditIcon = importSvg(() => import("../assets/icons/control/edit.svg"));
+const ViewIcon = importSvg(() => import("../assets/icons/control/view.svg"));
+const MoreVerticalIcon = importSvg(() =>
   import("../assets/icons/control/more-vertical.svg"),
 );
-const OverflowMenuIcon = loadableForSvg(() =>
+const OverflowMenuIcon = importSvg(() =>
   import("../assets/icons/menu/overflow-menu.svg"),
 );
-const JsToggleIcon = loadableForSvg(() =>
+const JsToggleIcon = importSvg(() =>
   import("../assets/icons/control/js-toggle.svg"),
 );
-const IncreaseIcon = loadableForSvg(() =>
+const IncreaseIcon = importSvg(() =>
   import("../assets/icons/control/increase.svg"),
 );
-const DecreaseIcon = loadableForSvg(() =>
+const DecreaseIcon = importSvg(() =>
   import("../assets/icons/control/decrease.svg"),
 );
-const DraggableIcon = loadableForSvg(() =>
+const DraggableIcon = importSvg(() =>
   import("../assets/icons/control/draggable.svg"),
 );
-const CloseCircleIcon = loadableForSvg(() =>
+const CloseCircleIcon = importSvg(() =>
   import("../assets/icons/control/close-circle.svg"),
 );
-const AddCircleIcon = loadableForSvg(() =>
+const AddCircleIcon = importSvg(() =>
   import("../assets/icons/control/add-circle.svg"),
 );
-const HelpIcon = loadableForSvg(() =>
-  import("../assets/icons/control/help.svg"),
-);
-const CollapseIcon = loadableForSvg(() =>
+const HelpIcon = importSvg(() => import("../assets/icons/control/help.svg"));
+const CollapseIcon = importSvg(() =>
   import("../assets/icons/control/collapse.svg"),
 );
-const PickMyLocationSelectedIcon = loadableForSvg(() =>
+const PickMyLocationSelectedIcon = importSvg(() =>
   import("../assets/icons/control/pick-location-selected.svg"),
 );
-const RemoveIcon = loadableForSvg(() =>
+const RemoveIcon = importSvg(() =>
   import("../assets/icons/control/remove.svg"),
 );
-const DragIcon = loadableForSvg(() =>
-  import("../assets/icons/control/drag.svg"),
-);
-const SortIcon = loadableForSvg(() =>
+const DragIcon = importSvg(() => import("../assets/icons/control/drag.svg"));
+const SortIcon = importSvg(() =>
   import("../assets/icons/control/sort-icon.svg"),
 );
-const EditWhiteIcon = loadableForSvg(() =>
+const EditWhiteIcon = importSvg(() =>
   import("../assets/icons/control/edit-white.svg"),
 );
-const LaunchIcon = loadableForSvg(() =>
+const LaunchIcon = importSvg(() =>
   import("../assets/icons/control/launch.svg"),
 );
-const BackIcon = loadableForSvg(() =>
-  import("../assets/icons/control/back.svg"),
-);
-const DeleteColumnIcon = loadableForSvg(() =>
+const BackIcon = importSvg(() => import("../assets/icons/control/back.svg"));
+const DeleteColumnIcon = importSvg(() =>
   import("../assets/icons/control/delete-column.svg"),
 );
-const BoldFontIcon = loadableForSvg(() =>
+const BoldFontIcon = importSvg(() =>
   import("../assets/icons/control/bold.svg"),
 );
-const UnderlineIcon = loadableForSvg(() =>
+const UnderlineIcon = importSvg(() =>
   import("../assets/icons/control/underline.svg"),
 );
-const ItalicsFontIcon = loadableForSvg(() =>
+const ItalicsFontIcon = importSvg(() =>
   import("../assets/icons/control/italics.svg"),
 );
-const LeftAlignIcon = loadableForSvg(() =>
+const LeftAlignIcon = importSvg(() =>
   import("../assets/icons/control/left-align.svg"),
 );
-const CenterAlignIcon = loadableForSvg(() =>
+const CenterAlignIcon = importSvg(() =>
   import("../assets/icons/control/center-align.svg"),
 );
-const RightAlignIcon = loadableForSvg(() =>
+const RightAlignIcon = importSvg(() =>
   import("../assets/icons/control/right-align.svg"),
 );
-const VerticalAlignRight = loadableForSvg(() =>
+const VerticalAlignRight = importSvg(() =>
   import("../assets/icons/control/align_right.svg"),
 );
-const VerticalAlignLeft = loadableForSvg(() =>
+const VerticalAlignLeft = importSvg(() =>
   import("../assets/icons/control/align_left.svg"),
 );
-const VerticalAlignBottom = loadableForSvg(() =>
+const VerticalAlignBottom = importSvg(() =>
   import("../assets/icons/control/vertical_align_bottom.svg"),
 );
-const VerticalAlignCenter = loadableForSvg(() =>
+const VerticalAlignCenter = importSvg(() =>
   import("../assets/icons/control/vertical_align_center.svg"),
 );
-const VerticalAlignTop = loadableForSvg(() =>
+const VerticalAlignTop = importSvg(() =>
   import("../assets/icons/control/vertical_align_top.svg"),
 );
-const Copy2Icon = loadableForSvg(() =>
-  import("../assets/icons/control/copy2.svg"),
-);
-const CutIcon = loadableForSvg(() => import("../assets/icons/control/cut.svg"));
-const GroupIcon = loadableForSvg(() =>
-  import("../assets/icons/control/group.svg"),
-);
-const HeadingOneIcon = loadableForSvg(() =>
+const Copy2Icon = importSvg(() => import("../assets/icons/control/copy2.svg"));
+const CutIcon = importSvg(() => import("../assets/icons/control/cut.svg"));
+const GroupIcon = importSvg(() => import("../assets/icons/control/group.svg"));
+const HeadingOneIcon = importSvg(() =>
   import("../assets/icons/control/heading_1.svg"),
 );
-const HeadingTwoIcon = loadableForSvg(() =>
+const HeadingTwoIcon = importSvg(() =>
   import("../assets/icons/control/heading_2.svg"),
 );
-const HeadingThreeIcon = loadableForSvg(() =>
+const HeadingThreeIcon = importSvg(() =>
   import("../assets/icons/control/heading_3.svg"),
 );
-const ParagraphIcon = loadableForSvg(() =>
+const ParagraphIcon = importSvg(() =>
   import("../assets/icons/control/paragraph.svg"),
 );
-const ParagraphTwoIcon = loadableForSvg(() =>
+const ParagraphTwoIcon = importSvg(() =>
   import("../assets/icons/control/paragraph_2.svg"),
 );
-const BulletsIcon = loadableForSvg(() =>
+const BulletsIcon = importSvg(() =>
   import("../assets/icons/control/bullets.svg"),
 );
-const DividerCapRightIcon = loadableForSvg(() =>
+const DividerCapRightIcon = importSvg(() =>
   import("../assets/icons/control/divider_cap_right.svg"),
 );
-const DividerCapLeftIcon = loadableForSvg(() =>
+const DividerCapLeftIcon = importSvg(() =>
   import("../assets/icons/control/divider_cap_left.svg"),
 );
-const DividerCapAllIcon = loadableForSvg(() =>
+const DividerCapAllIcon = importSvg(() =>
   import("../assets/icons/control/divider_cap_all.svg"),
 );
-const TrendingFlat = loadableForSvg(() =>
+const TrendingFlat = importSvg(() =>
   import("../assets/icons/ads/trending-flat.svg"),
 );
-const AlignLeftIcon = loadableForSvg(() =>
+const AlignLeftIcon = importSvg(() =>
   import("../assets/icons/control/align_left.svg"),
 );
-const AlignRightIcon = loadableForSvg(() =>
+const AlignRightIcon = importSvg(() =>
   import("../assets/icons/control/align_right.svg"),
 );
-const BorderRadiusSharpIcon = loadableForSvg(() =>
+const BorderRadiusSharpIcon = importSvg(() =>
   import("../assets/icons/control/border-radius-sharp.svg"),
 );
-const BorderRadiusRoundedIcon = loadableForSvg(() =>
+const BorderRadiusRoundedIcon = importSvg(() =>
   import("../assets/icons/control/border-radius-rounded.svg"),
 );
-const BorderRadiusCircleIcon = loadableForSvg(() =>
+const BorderRadiusCircleIcon = importSvg(() =>
   import("../assets/icons/control/border-radius-circle.svg"),
 );
-const BoxShadowNoneIcon = loadableForSvg(() =>
+const BoxShadowNoneIcon = importSvg(() =>
   import("../assets/icons/control/box-shadow-none.svg"),
 );
-const BoxShadowVariant1Icon = loadableForSvg(() =>
+const BoxShadowVariant1Icon = importSvg(() =>
   import("../assets/icons/control/box-shadow-variant1.svg"),
 );
-const BoxShadowVariant2Icon = loadableForSvg(() =>
+const BoxShadowVariant2Icon = importSvg(() =>
   import("../assets/icons/control/box-shadow-variant2.svg"),
 );
-const BoxShadowVariant3Icon = loadableForSvg(() =>
+const BoxShadowVariant3Icon = importSvg(() =>
   import("../assets/icons/control/box-shadow-variant3.svg"),
 );
-const BoxShadowVariant4Icon = loadableForSvg(() =>
+const BoxShadowVariant4Icon = importSvg(() =>
   import("../assets/icons/control/box-shadow-variant4.svg"),
 );
-const BoxShadowVariant5Icon = loadableForSvg(() =>
+const BoxShadowVariant5Icon = importSvg(() =>
   import("../assets/icons/control/box-shadow-variant5.svg"),
 );
-const IncreaseV2Icon = loadableForRemixIcons(() =>
+const IncreaseV2Icon = importRemixIcon(() =>
   import("remixicon-react/AddLineIcon"),
 );
-const CopyIcon = loadableForRemixIcons(() =>
+const CopyIcon = importRemixIcon(() =>
   import("remixicon-react/FileCopyLineIcon"),
 );
-const QuestionIcon = loadableForRemixIcons(() =>
+const QuestionIcon = importRemixIcon(() =>
   import("remixicon-react/QuestionLineIcon"),
 );
-const SettingsIcon = loadableForRemixIcons(() =>
+const SettingsIcon = importRemixIcon(() =>
   import("remixicon-react/Settings5LineIcon"),
 );
-const EyeIcon = loadableForRemixIcons(() =>
-  import("remixicon-react/EyeLineIcon"),
-);
-const EyeOffIcon = loadableForRemixIcons(() =>
+const EyeIcon = importRemixIcon(() => import("remixicon-react/EyeLineIcon"));
+const EyeOffIcon = importRemixIcon(() =>
   import("remixicon-react/EyeOffLineIcon"),
 );
-const CloseIcon = loadableForRemixIcons(() =>
+const CloseIcon = importRemixIcon(() =>
   import("remixicon-react/CloseLineIcon"),
 );
-const SubtractIcon = loadableForRemixIcons(() =>
+const SubtractIcon = importRemixIcon(() =>
   import("remixicon-react/SubtractFillIcon"),
 );
 

--- a/packages/design-system-old/src/ControlIcons/index.tsx
+++ b/packages/design-system-old/src/ControlIcons/index.tsx
@@ -1,71 +1,201 @@
 import React, { JSXElementConstructor } from "react";
 import { IconProps, IconWrapper } from "Constants/Icon";
-import { ReactComponent as DeleteIcon } from "../assets/icons/control/delete.svg";
-import { ReactComponent as MoveIcon } from "../assets/icons/control/move.svg";
-import { ReactComponent as EditIcon } from "../assets/icons/control/edit.svg";
-import { ReactComponent as ViewIcon } from "../assets/icons/control/view.svg";
-import { ReactComponent as MoreVerticalIcon } from "../assets/icons/control/more-vertical.svg";
-import { ReactComponent as OverflowMenuIcon } from "../assets/icons/menu/overflow-menu.svg";
-import { ReactComponent as JsToggleIcon } from "../assets/icons/control/js-toggle.svg";
-import { ReactComponent as IncreaseIcon } from "../assets/icons/control/increase.svg";
-import { ReactComponent as DecreaseIcon } from "../assets/icons/control/decrease.svg";
-import { ReactComponent as DraggableIcon } from "../assets/icons/control/draggable.svg";
-import { ReactComponent as CloseCircleIcon } from "../assets/icons/control/close-circle.svg";
-import { ReactComponent as AddCircleIcon } from "../assets/icons/control/add-circle.svg";
-import { ReactComponent as HelpIcon } from "../assets/icons/control/help.svg";
-import { ReactComponent as CollapseIcon } from "../assets/icons/control/collapse.svg";
-import { ReactComponent as PickMyLocationSelectedIcon } from "../assets/icons/control/pick-location-selected.svg";
-import { ReactComponent as RemoveIcon } from "../assets/icons/control/remove.svg";
-import { ReactComponent as DragIcon } from "../assets/icons/control/drag.svg";
-import { ReactComponent as SortIcon } from "../assets/icons/control/sort-icon.svg";
-import { ReactComponent as EditWhiteIcon } from "../assets/icons/control/edit-white.svg";
-import { ReactComponent as LaunchIcon } from "../assets/icons/control/launch.svg";
-import { ReactComponent as BackIcon } from "../assets/icons/control/back.svg";
-import { ReactComponent as DeleteColumnIcon } from "../assets/icons/control/delete-column.svg";
-import { ReactComponent as BoldFontIcon } from "../assets/icons/control/bold.svg";
-import { ReactComponent as UnderlineIcon } from "../assets/icons/control/underline.svg";
-import { ReactComponent as ItalicsFontIcon } from "../assets/icons/control/italics.svg";
-import { ReactComponent as LeftAlignIcon } from "../assets/icons/control/left-align.svg";
-import { ReactComponent as CenterAlignIcon } from "../assets/icons/control/center-align.svg";
-import { ReactComponent as RightAlignIcon } from "../assets/icons/control/right-align.svg";
-import { ReactComponent as VerticalAlignRight } from "../assets/icons/control/align_right.svg";
-import { ReactComponent as VerticalAlignLeft } from "../assets/icons/control/align_left.svg";
-import { ReactComponent as VerticalAlignBottom } from "../assets/icons/control/vertical_align_bottom.svg";
-import { ReactComponent as VerticalAlignCenter } from "../assets/icons/control/vertical_align_center.svg";
-import { ReactComponent as VerticalAlignTop } from "../assets/icons/control/vertical_align_top.svg";
-import { ReactComponent as Copy2Icon } from "../assets/icons/control/copy2.svg";
-import { ReactComponent as CutIcon } from "../assets/icons/control/cut.svg";
-import { ReactComponent as GroupIcon } from "../assets/icons/control/group.svg";
-import { ReactComponent as HeadingOneIcon } from "../assets/icons/control/heading_1.svg";
-import { ReactComponent as HeadingTwoIcon } from "../assets/icons/control/heading_2.svg";
-import { ReactComponent as HeadingThreeIcon } from "../assets/icons/control/heading_3.svg";
-import { ReactComponent as ParagraphIcon } from "../assets/icons/control/paragraph.svg";
-import { ReactComponent as ParagraphTwoIcon } from "../assets/icons/control/paragraph_2.svg";
-import { ReactComponent as BulletsIcon } from "../assets/icons/control/bullets.svg";
-import { ReactComponent as DividerCapRightIcon } from "../assets/icons/control/divider_cap_right.svg";
-import { ReactComponent as DividerCapLeftIcon } from "../assets/icons/control/divider_cap_left.svg";
-import { ReactComponent as DividerCapAllIcon } from "../assets/icons/control/divider_cap_all.svg";
-import { ReactComponent as TrendingFlat } from "../assets/icons/ads/trending-flat.svg";
-import { ReactComponent as AlignLeftIcon } from "../assets/icons/control/align_left.svg";
-import { ReactComponent as AlignRightIcon } from "../assets/icons/control/align_right.svg";
-import { ReactComponent as BorderRadiusSharpIcon } from "../assets/icons/control/border-radius-sharp.svg";
-import { ReactComponent as BorderRadiusRoundedIcon } from "../assets/icons/control/border-radius-rounded.svg";
-import { ReactComponent as BorderRadiusCircleIcon } from "../assets/icons/control/border-radius-circle.svg";
-import { ReactComponent as BoxShadowNoneIcon } from "../assets/icons/control/box-shadow-none.svg";
-import { ReactComponent as BoxShadowVariant1Icon } from "../assets/icons/control/box-shadow-variant1.svg";
-import { ReactComponent as BoxShadowVariant2Icon } from "../assets/icons/control/box-shadow-variant2.svg";
-import { ReactComponent as BoxShadowVariant3Icon } from "../assets/icons/control/box-shadow-variant3.svg";
-import { ReactComponent as BoxShadowVariant4Icon } from "../assets/icons/control/box-shadow-variant4.svg";
-import { ReactComponent as BoxShadowVariant5Icon } from "../assets/icons/control/box-shadow-variant5.svg";
-import IncreaseV2Icon from "remixicon-react/AddLineIcon";
+import { loadableForRemixIcons, loadableForSvg } from "Utils/icon-loadables";
 import PlayIcon from "../assets/icons/control/play-icon.png";
-import CopyIcon from "remixicon-react/FileCopyLineIcon";
-import QuestionIcon from "remixicon-react/QuestionLineIcon";
-import SettingsIcon from "remixicon-react/Settings5LineIcon";
-import EyeIcon from "remixicon-react/EyeLineIcon";
-import EyeOffIcon from "remixicon-react/EyeOffLineIcon";
-import CloseIcon from "remixicon-react/CloseLineIcon";
-import SubtractIcon from "remixicon-react/SubtractFillIcon";
+
+const DeleteIcon = loadableForSvg(() =>
+  import("../assets/icons/control/delete.svg"),
+);
+const MoveIcon = loadableForSvg(() =>
+  import("../assets/icons/control/move.svg"),
+);
+const EditIcon = loadableForSvg(() =>
+  import("../assets/icons/control/edit.svg"),
+);
+const ViewIcon = loadableForSvg(() =>
+  import("../assets/icons/control/view.svg"),
+);
+const MoreVerticalIcon = loadableForSvg(() =>
+  import("../assets/icons/control/more-vertical.svg"),
+);
+const OverflowMenuIcon = loadableForSvg(() =>
+  import("../assets/icons/menu/overflow-menu.svg"),
+);
+const JsToggleIcon = loadableForSvg(() =>
+  import("../assets/icons/control/js-toggle.svg"),
+);
+const IncreaseIcon = loadableForSvg(() =>
+  import("../assets/icons/control/increase.svg"),
+);
+const DecreaseIcon = loadableForSvg(() =>
+  import("../assets/icons/control/decrease.svg"),
+);
+const DraggableIcon = loadableForSvg(() =>
+  import("../assets/icons/control/draggable.svg"),
+);
+const CloseCircleIcon = loadableForSvg(() =>
+  import("../assets/icons/control/close-circle.svg"),
+);
+const AddCircleIcon = loadableForSvg(() =>
+  import("../assets/icons/control/add-circle.svg"),
+);
+const HelpIcon = loadableForSvg(() =>
+  import("../assets/icons/control/help.svg"),
+);
+const CollapseIcon = loadableForSvg(() =>
+  import("../assets/icons/control/collapse.svg"),
+);
+const PickMyLocationSelectedIcon = loadableForSvg(() =>
+  import("../assets/icons/control/pick-location-selected.svg"),
+);
+const RemoveIcon = loadableForSvg(() =>
+  import("../assets/icons/control/remove.svg"),
+);
+const DragIcon = loadableForSvg(() =>
+  import("../assets/icons/control/drag.svg"),
+);
+const SortIcon = loadableForSvg(() =>
+  import("../assets/icons/control/sort-icon.svg"),
+);
+const EditWhiteIcon = loadableForSvg(() =>
+  import("../assets/icons/control/edit-white.svg"),
+);
+const LaunchIcon = loadableForSvg(() =>
+  import("../assets/icons/control/launch.svg"),
+);
+const BackIcon = loadableForSvg(() =>
+  import("../assets/icons/control/back.svg"),
+);
+const DeleteColumnIcon = loadableForSvg(() =>
+  import("../assets/icons/control/delete-column.svg"),
+);
+const BoldFontIcon = loadableForSvg(() =>
+  import("../assets/icons/control/bold.svg"),
+);
+const UnderlineIcon = loadableForSvg(() =>
+  import("../assets/icons/control/underline.svg"),
+);
+const ItalicsFontIcon = loadableForSvg(() =>
+  import("../assets/icons/control/italics.svg"),
+);
+const LeftAlignIcon = loadableForSvg(() =>
+  import("../assets/icons/control/left-align.svg"),
+);
+const CenterAlignIcon = loadableForSvg(() =>
+  import("../assets/icons/control/center-align.svg"),
+);
+const RightAlignIcon = loadableForSvg(() =>
+  import("../assets/icons/control/right-align.svg"),
+);
+const VerticalAlignRight = loadableForSvg(() =>
+  import("../assets/icons/control/align_right.svg"),
+);
+const VerticalAlignLeft = loadableForSvg(() =>
+  import("../assets/icons/control/align_left.svg"),
+);
+const VerticalAlignBottom = loadableForSvg(() =>
+  import("../assets/icons/control/vertical_align_bottom.svg"),
+);
+const VerticalAlignCenter = loadableForSvg(() =>
+  import("../assets/icons/control/vertical_align_center.svg"),
+);
+const VerticalAlignTop = loadableForSvg(() =>
+  import("../assets/icons/control/vertical_align_top.svg"),
+);
+const Copy2Icon = loadableForSvg(() =>
+  import("../assets/icons/control/copy2.svg"),
+);
+const CutIcon = loadableForSvg(() => import("../assets/icons/control/cut.svg"));
+const GroupIcon = loadableForSvg(() =>
+  import("../assets/icons/control/group.svg"),
+);
+const HeadingOneIcon = loadableForSvg(() =>
+  import("../assets/icons/control/heading_1.svg"),
+);
+const HeadingTwoIcon = loadableForSvg(() =>
+  import("../assets/icons/control/heading_2.svg"),
+);
+const HeadingThreeIcon = loadableForSvg(() =>
+  import("../assets/icons/control/heading_3.svg"),
+);
+const ParagraphIcon = loadableForSvg(() =>
+  import("../assets/icons/control/paragraph.svg"),
+);
+const ParagraphTwoIcon = loadableForSvg(() =>
+  import("../assets/icons/control/paragraph_2.svg"),
+);
+const BulletsIcon = loadableForSvg(() =>
+  import("../assets/icons/control/bullets.svg"),
+);
+const DividerCapRightIcon = loadableForSvg(() =>
+  import("../assets/icons/control/divider_cap_right.svg"),
+);
+const DividerCapLeftIcon = loadableForSvg(() =>
+  import("../assets/icons/control/divider_cap_left.svg"),
+);
+const DividerCapAllIcon = loadableForSvg(() =>
+  import("../assets/icons/control/divider_cap_all.svg"),
+);
+const TrendingFlat = loadableForSvg(() =>
+  import("../assets/icons/ads/trending-flat.svg"),
+);
+const AlignLeftIcon = loadableForSvg(() =>
+  import("../assets/icons/control/align_left.svg"),
+);
+const AlignRightIcon = loadableForSvg(() =>
+  import("../assets/icons/control/align_right.svg"),
+);
+const BorderRadiusSharpIcon = loadableForSvg(() =>
+  import("../assets/icons/control/border-radius-sharp.svg"),
+);
+const BorderRadiusRoundedIcon = loadableForSvg(() =>
+  import("../assets/icons/control/border-radius-rounded.svg"),
+);
+const BorderRadiusCircleIcon = loadableForSvg(() =>
+  import("../assets/icons/control/border-radius-circle.svg"),
+);
+const BoxShadowNoneIcon = loadableForSvg(() =>
+  import("../assets/icons/control/box-shadow-none.svg"),
+);
+const BoxShadowVariant1Icon = loadableForSvg(() =>
+  import("../assets/icons/control/box-shadow-variant1.svg"),
+);
+const BoxShadowVariant2Icon = loadableForSvg(() =>
+  import("../assets/icons/control/box-shadow-variant2.svg"),
+);
+const BoxShadowVariant3Icon = loadableForSvg(() =>
+  import("../assets/icons/control/box-shadow-variant3.svg"),
+);
+const BoxShadowVariant4Icon = loadableForSvg(() =>
+  import("../assets/icons/control/box-shadow-variant4.svg"),
+);
+const BoxShadowVariant5Icon = loadableForSvg(() =>
+  import("../assets/icons/control/box-shadow-variant5.svg"),
+);
+const IncreaseV2Icon = loadableForRemixIcons(() =>
+  import("remixicon-react/AddLineIcon"),
+);
+const CopyIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/FileCopyLineIcon"),
+);
+const QuestionIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/QuestionLineIcon"),
+);
+const SettingsIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/Settings5LineIcon"),
+);
+const EyeIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/EyeLineIcon"),
+);
+const EyeOffIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/EyeOffLineIcon"),
+);
+const CloseIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/CloseLineIcon"),
+);
+const SubtractIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/SubtractFillIcon"),
+);
 
 /* eslint-disable react/display-name */
 

--- a/packages/design-system-old/src/DisplayImageUpload/index.tsx
+++ b/packages/design-system-old/src/DisplayImageUpload/index.tsx
@@ -17,9 +17,9 @@ import "@uppy/dashboard/dist/style.css";
 import "@uppy/image-editor/dist/style.css";
 import "@blueprintjs/popover2/lib/css/blueprint-popover2.css";
 import { getTypographyByKey } from "Constants/typography";
-import { loadableForSvg } from "Utils/icon-loadables";
+import { importSvg } from "Utils/icon-loadables";
 
-const ProfileImagePlaceholder = loadableForSvg(() =>
+const ProfileImagePlaceholder = importSvg(() =>
   import("../assets/icons/others/profile-placeholder.svg"),
 );
 

--- a/packages/design-system-old/src/DisplayImageUpload/index.tsx
+++ b/packages/design-system-old/src/DisplayImageUpload/index.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from "react";
-import { ReactComponent as ProfileImagePlaceholder } from "../assets/icons/others/profile-placeholder.svg";
 import Uppy from "@uppy/core";
 import Dialog from "DialogComponent";
 
@@ -18,6 +17,11 @@ import "@uppy/dashboard/dist/style.css";
 import "@uppy/image-editor/dist/style.css";
 import "@blueprintjs/popover2/lib/css/blueprint-popover2.css";
 import { getTypographyByKey } from "Constants/typography";
+import { loadableForSvg } from "Utils/icon-loadables";
+
+const ProfileImagePlaceholder = loadableForSvg(() =>
+  import("../assets/icons/others/profile-placeholder.svg"),
+);
 
 type Props = {
   onChange: (file: File) => void;

--- a/packages/design-system-old/src/Dropdown/index.tsx
+++ b/packages/design-system-old/src/Dropdown/index.tsx
@@ -23,11 +23,9 @@ import Tooltip from "Tooltip";
 import SegmentHeader from "ListSegmentHeader";
 import { debounce, isArray } from "lodash";
 import "./styles.css";
-import { loadableForSvg } from "Utils/icon-loadables";
+import { importSvg } from "utils/icon-loadables";
 
-const Check = loadableForSvg(() =>
-  import("../assets/icons/control/checkmark.svg"),
-);
+const Check = importSvg(() => import("../assets/icons/control/checkmark.svg"));
 
 export type DropdownOnSelect = (
   value?: string,

--- a/packages/design-system-old/src/Dropdown/index.tsx
+++ b/packages/design-system-old/src/Dropdown/index.tsx
@@ -19,11 +19,15 @@ import { typography } from "Constants/typography";
 import styled from "styled-components";
 import SearchComponent from "SearchComponent";
 import Spinner from "Spinner";
-import { ReactComponent as Check } from "../assets/icons/control/checkmark.svg";
 import Tooltip from "Tooltip";
 import SegmentHeader from "ListSegmentHeader";
 import { debounce, isArray } from "lodash";
 import "./styles.css";
+import { loadableForSvg } from "Utils/icon-loadables";
+
+const Check = loadableForSvg(() =>
+  import("../assets/icons/control/checkmark.svg"),
+);
 
 export type DropdownOnSelect = (
   value?: string,
@@ -948,7 +952,9 @@ export function RenderDropdownOptions(props: DropdownOptionsProps) {
                 subTextPosition={option.subTextPosition ?? SubTextPosition.LEFT}
               >
                 {option.leftElement && (
-                  <LeftIconWrapper className="left-icon-wrapper">{option.leftElement}</LeftIconWrapper>
+                  <LeftIconWrapper className="left-icon-wrapper">
+                    {option.leftElement}
+                  </LeftIconWrapper>
                 )}
                 {option.icon ? (
                   <SelectedIcon

--- a/packages/design-system-old/src/FilePickerV2/index.tsx
+++ b/packages/design-system-old/src/FilePickerV2/index.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useRef, useState } from "react";
 import styled from "styled-components";
-import { ReactComponent as UploadSuccessIcon } from "../assets/icons/ads/upload_success.svg";
 import { DndProvider, useDrop, DropTargetMonitor } from "react-dnd";
 import HTML5Backend, { NativeTypes } from "react-dnd-html5-backend";
 import { Variant } from "Constants/variants";
@@ -15,6 +14,11 @@ import {
   REMOVE_FILE_TOOL_TIP,
 } from "Constants/messages";
 import { Classes } from "Constants/classes";
+import { loadableForSvg } from "Utils/icon-loadables";
+
+const UploadSuccessIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/upload_success.svg"),
+);
 
 export const FileEndings = {
   IMAGE: ".jpeg,.png,.svg",
@@ -194,7 +198,13 @@ const UploadIconWrapper = styled.div`
 `;
 
 function FilePickerComponent(props: FilePickerProps) {
-  const { fileType, logoUploadError, onFileRemoved, onFileUploaded, fileUploader } = props;
+  const {
+    fileType,
+    logoUploadError,
+    onFileRemoved,
+    onFileUploaded,
+    fileUploader,
+  } = props;
   const [fileInfo, setFileInfo] = useState<{ name: string; size: number }>({
     name: "",
     size: 0,

--- a/packages/design-system-old/src/FilePickerV2/index.tsx
+++ b/packages/design-system-old/src/FilePickerV2/index.tsx
@@ -14,9 +14,9 @@ import {
   REMOVE_FILE_TOOL_TIP,
 } from "Constants/messages";
 import { Classes } from "Constants/classes";
-import { loadableForSvg } from "Utils/icon-loadables";
+import { importSvg } from "Utils/icon-loadables";
 
-const UploadSuccessIcon = loadableForSvg(() =>
+const UploadSuccessIcon = importSvg(() =>
   import("../assets/icons/ads/upload_success.svg"),
 );
 

--- a/packages/design-system-old/src/Icon/index.tsx
+++ b/packages/design-system-old/src/Icon/index.tsx
@@ -5,515 +5,463 @@ import { Classes } from "Constants/classes";
 import { noop } from "lodash";
 import Spinner from "Spinner";
 import { ControlIcons } from "ControlIcons";
-import { loadableForRemixIcons, loadableForSvg } from "utils/icon-loadables";
+import { importRemixIcon, importSvg } from "utils/icon-loadables";
 
-const BookLineIcon = loadableForSvg(() =>
+const BookLineIcon = importSvg(() =>
   import("../assets/icons/ads/book-open-line.svg"),
 );
-const BugIcon = loadableForSvg(() => import("../assets/icons/ads/bug.svg"));
-const CancelIcon = loadableForSvg(() =>
-  import("../assets/icons/ads/cancel.svg"),
-);
-const CrossIcon = loadableForSvg(() => import("../assets/icons/ads/cross.svg"));
-const Fork2Icon = loadableForSvg(() =>
-  import("../assets/icons/ads/fork-2.svg"),
-);
-const OpenIcon = loadableForSvg(() => import("../assets/icons/ads/open.svg"));
-const UserIcon = loadableForSvg(() => import("../assets/icons/ads/user.svg"));
-const GeneralIcon = loadableForSvg(() =>
-  import("../assets/icons/ads/general.svg"),
-);
-const BillingIcon = loadableForSvg(() =>
-  import("../assets/icons/ads/billing.svg"),
-);
-const ErrorIcon = loadableForSvg(() => import("../assets/icons/ads/error.svg"));
-const ShineIcon = loadableForSvg(() => import("../assets/icons/ads/shine.svg"));
-const SuccessIcon = loadableForSvg(() =>
-  import("../assets/icons/ads/success.svg"),
-);
-const CloseIcon = loadableForSvg(() => import("../assets/icons/ads/close.svg"));
-const WarningTriangleIcon = loadableForSvg(() =>
+const BugIcon = importSvg(() => import("../assets/icons/ads/bug.svg"));
+const CancelIcon = importSvg(() => import("../assets/icons/ads/cancel.svg"));
+const CrossIcon = importSvg(() => import("../assets/icons/ads/cross.svg"));
+const Fork2Icon = importSvg(() => import("../assets/icons/ads/fork-2.svg"));
+const OpenIcon = importSvg(() => import("../assets/icons/ads/open.svg"));
+const UserIcon = importSvg(() => import("../assets/icons/ads/user.svg"));
+const GeneralIcon = importSvg(() => import("../assets/icons/ads/general.svg"));
+const BillingIcon = importSvg(() => import("../assets/icons/ads/billing.svg"));
+const ErrorIcon = importSvg(() => import("../assets/icons/ads/error.svg"));
+const ShineIcon = importSvg(() => import("../assets/icons/ads/shine.svg"));
+const SuccessIcon = importSvg(() => import("../assets/icons/ads/success.svg"));
+const CloseIcon = importSvg(() => import("../assets/icons/ads/close.svg"));
+const WarningTriangleIcon = importSvg(() =>
   import("../assets/icons/ads/warning-triangle.svg"),
 );
-const ShareIcon2 = loadableForSvg(() =>
-  import("../assets/icons/ads/share-2.svg"),
-);
-const InviteUserIcon = loadableForSvg(() =>
+const ShareIcon2 = importSvg(() => import("../assets/icons/ads/share-2.svg"));
+const InviteUserIcon = importSvg(() =>
   import("../assets/icons/ads/invite-users.svg"),
 );
-const ManageIcon = loadableForSvg(() =>
-  import("../assets/icons/ads/manage.svg"),
-);
-const ArrowLeft = loadableForSvg(() =>
-  import("../assets/icons/ads/arrow-left.svg"),
-);
-const ChevronLeft = loadableForSvg(() =>
+const ManageIcon = importSvg(() => import("../assets/icons/ads/manage.svg"));
+const ArrowLeft = importSvg(() => import("../assets/icons/ads/arrow-left.svg"));
+const ChevronLeft = importSvg(() =>
   import("../assets/icons/ads/chevron_left.svg"),
 );
-const LinkIcon = loadableForSvg(() => import("../assets/icons/ads/link.svg"));
-const NoResponseIcon = loadableForSvg(() =>
+const LinkIcon = importSvg(() => import("../assets/icons/ads/link.svg"));
+const NoResponseIcon = importSvg(() =>
   import("../assets/icons/ads/no-response.svg"),
 );
-const LightningIcon = loadableForSvg(() =>
+const LightningIcon = importSvg(() =>
   import("../assets/icons/ads/lightning.svg"),
 );
-const TrendingFlat = loadableForSvg(() =>
+const TrendingFlat = importSvg(() =>
   import("../assets/icons/ads/trending-flat.svg"),
 );
-const PlayIcon = loadableForSvg(() => import("../assets/icons/ads/play.svg"));
-const DesktopIcon = loadableForSvg(() =>
-  import("../assets/icons/ads/desktop.svg"),
-);
-const WandIcon = loadableForSvg(() => import("../assets/icons/ads/wand.svg"));
-const MobileIcon = loadableForSvg(() =>
-  import("../assets/icons/ads/mobile.svg"),
-);
-const TabletIcon = loadableForSvg(() =>
-  import("../assets/icons/ads/tablet.svg"),
-);
-const TabletLandscapeIcon = loadableForSvg(() =>
+const PlayIcon = importSvg(() => import("../assets/icons/ads/play.svg"));
+const DesktopIcon = importSvg(() => import("../assets/icons/ads/desktop.svg"));
+const WandIcon = importSvg(() => import("../assets/icons/ads/wand.svg"));
+const MobileIcon = importSvg(() => import("../assets/icons/ads/mobile.svg"));
+const TabletIcon = importSvg(() => import("../assets/icons/ads/tablet.svg"));
+const TabletLandscapeIcon = importSvg(() =>
   import("../assets/icons/ads/tablet-landscape.svg"),
 );
-const FluidIcon = loadableForSvg(() => import("../assets/icons/ads/fluid.svg"));
-const CardContextMenu = loadableForSvg(() =>
+const FluidIcon = importSvg(() => import("../assets/icons/ads/fluid.svg"));
+const CardContextMenu = importSvg(() =>
   import("../assets/icons/ads/card-context-menu.svg"),
 );
-const SendButton = loadableForSvg(() =>
+const SendButton = importSvg(() =>
   import("../assets/icons/comments/send-button.svg"),
 );
-const Pin = loadableForSvg(() => import("../assets/icons/comments/pin.svg"));
-const TrashOutline = loadableForSvg(() =>
-  import("../assets/icons/form/trash.svg"),
-);
-const ReadPin = loadableForSvg(() =>
+const Pin = importSvg(() => import("../assets/icons/comments/pin.svg"));
+const TrashOutline = importSvg(() => import("../assets/icons/form/trash.svg"));
+const ReadPin = importSvg(() =>
   import("../assets/icons/comments/read-pin.svg"),
 );
-const UnreadPin = loadableForSvg(() =>
+const UnreadPin = importSvg(() =>
   import("../assets/icons/comments/unread-pin.svg"),
 );
-const Chat = loadableForSvg(() => import("../assets/icons/comments/chat.svg"));
-const Unpin = loadableForSvg(() =>
-  import("../assets/icons/comments/unpinIcon.svg"),
-);
-const Reaction = loadableForSvg(() =>
+const Chat = importSvg(() => import("../assets/icons/comments/chat.svg"));
+const Unpin = importSvg(() => import("../assets/icons/comments/unpinIcon.svg"));
+const Reaction = importSvg(() =>
   import("../assets/icons/comments/reaction.svg"),
 );
-const Reaction2 = loadableForSvg(() =>
+const Reaction2 = importSvg(() =>
   import("../assets/icons/comments/reaction-2.svg"),
 );
-const Upload = loadableForSvg(() => import("../assets/icons/ads/upload.svg"));
-const ArrowForwardIcon = loadableForSvg(() =>
+const Upload = importSvg(() => import("../assets/icons/ads/upload.svg"));
+const ArrowForwardIcon = importSvg(() =>
   import("../assets/icons/control/arrow_forward.svg"),
 );
-const DoubleArrowRightIcon = loadableForSvg(() =>
+const DoubleArrowRightIcon = importSvg(() =>
   import("../assets/icons/ads/double-arrow-right.svg"),
 );
-const CapSolidIcon = loadableForSvg(() =>
+const CapSolidIcon = importSvg(() =>
   import("../assets/icons/control/cap_solid.svg"),
 );
-const CapDotIcon = loadableForSvg(() =>
+const CapDotIcon = importSvg(() =>
   import("../assets/icons/control/cap_dot.svg"),
 );
-const LineDottedIcon = loadableForSvg(() =>
+const LineDottedIcon = importSvg(() =>
   import("../assets/icons/control/line_dotted.svg"),
 );
-const LineDashedIcon = loadableForSvg(() =>
+const LineDashedIcon = importSvg(() =>
   import("../assets/icons/control/line_dashed.svg"),
 );
-const TableIcon = loadableForSvg(() =>
-  import("../assets/icons/ads/tables.svg"),
-);
-const ColumnIcon = loadableForSvg(() =>
-  import("../assets/icons/ads/column.svg"),
-);
-const GearIcon = loadableForSvg(() => import("../assets/icons/ads/gear.svg"));
-const UserV2Icon = loadableForSvg(() =>
-  import("../assets/icons/ads/user-v2.svg"),
-);
-const SupportIcon = loadableForSvg(() =>
-  import("../assets/icons/ads/support.svg"),
-);
-const Snippet = loadableForSvg(() => import("../assets/icons/ads/snippet.svg"));
-const WorkspaceIcon = loadableForSvg(() =>
+const TableIcon = importSvg(() => import("../assets/icons/ads/tables.svg"));
+const ColumnIcon = importSvg(() => import("../assets/icons/ads/column.svg"));
+const GearIcon = importSvg(() => import("../assets/icons/ads/gear.svg"));
+const UserV2Icon = importSvg(() => import("../assets/icons/ads/user-v2.svg"));
+const SupportIcon = importSvg(() => import("../assets/icons/ads/support.svg"));
+const Snippet = importSvg(() => import("../assets/icons/ads/snippet.svg"));
+const WorkspaceIcon = importSvg(() =>
   import("../assets/icons/ads/workspaceIcon.svg"),
 );
-const SettingIcon = loadableForSvg(() =>
+const SettingIcon = importSvg(() =>
   import("../assets/icons/control/settings.svg"),
 );
-const DropdownIcon = loadableForSvg(() =>
+const DropdownIcon = importSvg(() =>
   import("../assets/icons/ads/dropdown.svg"),
 );
-const ChatIcon = loadableForSvg(() =>
+const ChatIcon = importSvg(() =>
   import("../assets/icons/ads/app-icons/chat.svg"),
 );
-const JsIcon = loadableForSvg(() => import("../assets/icons/ads/js.svg"));
-const ExecuteIcon = loadableForSvg(() =>
-  import("../assets/icons/ads/execute.svg"),
-);
-const PackageIcon = loadableForSvg(() =>
-  import("../assets/icons/ads/package.svg"),
-);
+const JsIcon = importSvg(() => import("../assets/icons/ads/js.svg"));
+const ExecuteIcon = importSvg(() => import("../assets/icons/ads/execute.svg"));
+const PackageIcon = importSvg(() => import("../assets/icons/ads/package.svg"));
 
 // remix icons
-const AddMoreIcon = loadableForRemixIcons(() =>
+const AddMoreIcon = importRemixIcon(() =>
   import("remixicon-react/AddCircleLineIcon"),
 );
-const AddMoreFillIcon = loadableForRemixIcons(() =>
+const AddMoreFillIcon = importRemixIcon(() =>
   import("remixicon-react/AddCircleFillIcon"),
 );
-const ArrowLeftRightIcon = loadableForRemixIcons(() =>
+const ArrowLeftRightIcon = importRemixIcon(() =>
   import("remixicon-react/ArrowLeftRightLineIcon"),
 );
-const ArrowDownLineIcon = loadableForRemixIcons(() =>
+const ArrowDownLineIcon = importRemixIcon(() =>
   import("remixicon-react/ArrowDownLineIcon"),
 );
-const BookIcon = loadableForRemixIcons(() =>
+const BookIcon = importRemixIcon(() =>
   import("remixicon-react/BookOpenLineIcon"),
 );
-const BugLineIcon = loadableForRemixIcons(() =>
+const BugLineIcon = importRemixIcon(() =>
   import("remixicon-react/BugLineIcon"),
 );
-const ChevronRight = loadableForRemixIcons(() =>
+const ChevronRight = importRemixIcon(() =>
   import("remixicon-react/ArrowRightSFillIcon"),
 );
-const CheckLineIcon = loadableForRemixIcons(() =>
+const CheckLineIcon = importRemixIcon(() =>
   import("remixicon-react/CheckLineIcon"),
 );
-const CloseLineIcon = loadableForRemixIcons(() =>
+const CloseLineIcon = importRemixIcon(() =>
   import("remixicon-react/CloseLineIcon"),
 );
-const CloseCircleIcon = loadableForRemixIcons(() =>
+const CloseCircleIcon = importRemixIcon(() =>
   import("remixicon-react/CloseCircleFillIcon"),
 );
-const CloudOfflineIcon = loadableForRemixIcons(() =>
+const CloudOfflineIcon = importRemixIcon(() =>
   import("remixicon-react/CloudOffLineIcon"),
 );
-const CommentContextMenu = loadableForRemixIcons(() =>
+const CommentContextMenu = importRemixIcon(() =>
   import("remixicon-react/More2FillIcon"),
 );
-const More2FillIcon = loadableForRemixIcons(() =>
+const More2FillIcon = importRemixIcon(() =>
   import("remixicon-react/More2FillIcon"),
 );
-const CompassesLine = loadableForRemixIcons(() =>
+const CompassesLine = importRemixIcon(() =>
   import("remixicon-react/CompassesLineIcon"),
 );
-const ContextMenuIcon = loadableForRemixIcons(() =>
+const ContextMenuIcon = importRemixIcon(() =>
   import("remixicon-react/MoreFillIcon"),
 );
-const CreateNewIcon = loadableForRemixIcons(() =>
+const CreateNewIcon = importRemixIcon(() =>
   import("remixicon-react/AddLineIcon"),
 );
-const Database2Line = loadableForRemixIcons(() =>
+const Database2Line = importRemixIcon(() =>
   import("remixicon-react/Database2LineIcon"),
 );
-const DatasourceIcon = loadableForRemixIcons(() =>
+const DatasourceIcon = importRemixIcon(() =>
   import("remixicon-react/CloudFillIcon"),
 );
-const DeleteBin7 = loadableForRemixIcons(() =>
+const DeleteBin7 = importRemixIcon(() =>
   import("remixicon-react/DeleteBin7LineIcon"),
 );
-const DiscordIcon = loadableForRemixIcons(() =>
+const DiscordIcon = importRemixIcon(() =>
   import("remixicon-react/DiscordLineIcon"),
 );
-const DownArrow = loadableForRemixIcons(() =>
+const DownArrow = importRemixIcon(() =>
   import("remixicon-react/ArrowDownSFillIcon"),
 );
-const Download = loadableForRemixIcons(() =>
+const Download = importRemixIcon(() =>
   import("remixicon-react/DownloadCloud2LineIcon"),
 );
-const DuplicateIcon = loadableForRemixIcons(() =>
+const DuplicateIcon = importRemixIcon(() =>
   import("remixicon-react/FileCopyLineIcon"),
 );
-const EditIcon = loadableForRemixIcons(() =>
+const EditIcon = importRemixIcon(() =>
   import("remixicon-react/PencilFillIcon"),
 );
-const EditLineIcon = loadableForRemixIcons(() =>
+const EditLineIcon = importRemixIcon(() =>
   import("remixicon-react/EditLineIcon"),
 );
-const EditUnderlineIcon = loadableForRemixIcons(() =>
+const EditUnderlineIcon = importRemixIcon(() =>
   import("remixicon-react/EditLineIcon"),
 );
-const Emoji = loadableForRemixIcons(() =>
-  import("remixicon-react/EmotionLineIcon"),
-);
-const ExpandMore = loadableForRemixIcons(() =>
+const Emoji = importRemixIcon(() => import("remixicon-react/EmotionLineIcon"));
+const ExpandMore = importRemixIcon(() =>
   import("remixicon-react/ArrowDownSLineIcon"),
 );
-const DownArrowIcon = loadableForRemixIcons(() =>
+const DownArrowIcon = importRemixIcon(() =>
   import("remixicon-react/ArrowDownSLineIcon"),
 );
-const ExpandLess = loadableForRemixIcons(() =>
+const ExpandLess = importRemixIcon(() =>
   import("remixicon-react/ArrowUpSLineIcon"),
 );
-const EyeOn = loadableForRemixIcons(() =>
-  import("remixicon-react/EyeLineIcon"),
-);
-const EyeOff = loadableForRemixIcons(() =>
-  import("remixicon-react/EyeOffLineIcon"),
-);
-const FileTransfer = loadableForRemixIcons(() =>
+const EyeOn = importRemixIcon(() => import("remixicon-react/EyeLineIcon"));
+const EyeOff = importRemixIcon(() => import("remixicon-react/EyeOffLineIcon"));
+const FileTransfer = importRemixIcon(() =>
   import("remixicon-react/FileTransferLineIcon"),
 );
-const FileLine = loadableForRemixIcons(() =>
-  import("remixicon-react/FileLineIcon"),
-);
-const Filter = loadableForRemixIcons(() =>
-  import("remixicon-react/Filter2FillIcon"),
-);
-const ForbidLineIcon = loadableForRemixIcons(() =>
+const FileLine = importRemixIcon(() => import("remixicon-react/FileLineIcon"));
+const Filter = importRemixIcon(() => import("remixicon-react/Filter2FillIcon"));
+const ForbidLineIcon = importRemixIcon(() =>
   import("remixicon-react/ForbidLineIcon"),
 );
-const GitMerge = loadableForRemixIcons(() =>
+const GitMerge = importRemixIcon(() =>
   import("remixicon-react/GitMergeLineIcon"),
 );
-const GitCommit = loadableForRemixIcons(() =>
+const GitCommit = importRemixIcon(() =>
   import("remixicon-react/GitCommitLineIcon"),
 );
-const GitPullRequst = loadableForRemixIcons(() =>
+const GitPullRequst = importRemixIcon(() =>
   import("remixicon-react/GitPullRequestLineIcon"),
 );
-const GlobalLineIcon = loadableForRemixIcons(() =>
+const GlobalLineIcon = importRemixIcon(() =>
   import("remixicon-react/GlobalLineIcon"),
 );
-const GuideIcon = loadableForRemixIcons(() =>
+const GuideIcon = importRemixIcon(() =>
   import("remixicon-react/GuideFillIcon"),
 );
-const HelpIcon = loadableForRemixIcons(() =>
+const HelpIcon = importRemixIcon(() =>
   import("remixicon-react/QuestionMarkIcon"),
 );
-const LightbulbFlashLine = loadableForRemixIcons(() =>
+const LightbulbFlashLine = importRemixIcon(() =>
   import("remixicon-react/LightbulbFlashLineIcon"),
 );
-const LinksLineIcon = loadableForRemixIcons(() =>
+const LinksLineIcon = importRemixIcon(() =>
   import("remixicon-react/LinksLineIcon"),
 );
-const InfoIcon = loadableForRemixIcons(() =>
+const InfoIcon = importRemixIcon(() =>
   import("remixicon-react/InformationLineIcon"),
 );
-const KeyIcon = loadableForRemixIcons(() =>
-  import("remixicon-react/Key2LineIcon"),
-);
-const LeftArrowIcon2 = loadableForRemixIcons(() =>
+const KeyIcon = importRemixIcon(() => import("remixicon-react/Key2LineIcon"));
+const LeftArrowIcon2 = importRemixIcon(() =>
   import("remixicon-react/ArrowLeftSLineIcon"),
 );
-const Link2 = loadableForRemixIcons(() => import("remixicon-react/LinkIcon"));
-const LeftArrowIcon = loadableForRemixIcons(() =>
+const Link2 = importRemixIcon(() => import("remixicon-react/LinkIcon"));
+const LeftArrowIcon = importRemixIcon(() =>
   import("remixicon-react/ArrowLeftLineIcon"),
 );
-const NewsPaperLine = loadableForRemixIcons(() =>
+const NewsPaperLine = importRemixIcon(() =>
   import("remixicon-react/NewspaperLineIcon"),
 );
-const OvalCheck = loadableForRemixIcons(() =>
+const OvalCheck = importRemixIcon(() =>
   import("remixicon-react/CheckboxCircleLineIcon"),
 );
-const OvalCheckFill = loadableForRemixIcons(() =>
+const OvalCheckFill = importRemixIcon(() =>
   import("remixicon-react/CheckboxCircleFillIcon"),
 );
-const Pin3 = loadableForRemixIcons(() =>
-  import("remixicon-react/Pushpin2FillIcon"),
-);
-const PlayCircleLineIcon = loadableForRemixIcons(() =>
+const Pin3 = importRemixIcon(() => import("remixicon-react/Pushpin2FillIcon"));
+const PlayCircleLineIcon = importRemixIcon(() =>
   import("remixicon-react/PlayCircleLineIcon"),
 );
-const QueryIcon = loadableForRemixIcons(() =>
+const QueryIcon = importRemixIcon(() =>
   import("remixicon-react/CodeSSlashLineIcon"),
 );
-const RemoveIcon = loadableForRemixIcons(() =>
+const RemoveIcon = importRemixIcon(() =>
   import("remixicon-react/SubtractLineIcon"),
 );
-const RightArrowIcon = loadableForRemixIcons(() =>
+const RightArrowIcon = importRemixIcon(() =>
   import("remixicon-react/ArrowRightLineIcon"),
 );
-const RightArrowIcon2 = loadableForRemixIcons(() =>
+const RightArrowIcon2 = importRemixIcon(() =>
   import("remixicon-react/ArrowRightSLineIcon"),
 );
-const RocketIcon = loadableForRemixIcons(() =>
+const RocketIcon = importRemixIcon(() =>
   import("remixicon-react/RocketLineIcon"),
 );
-const SearchIcon = loadableForRemixIcons(() =>
+const SearchIcon = importRemixIcon(() =>
   import("remixicon-react/SearchLineIcon"),
 );
-const SortAscIcon = loadableForRemixIcons(() =>
+const SortAscIcon = importRemixIcon(() =>
   import("remixicon-react/SortAscIcon"),
 );
-const SortDescIcon = loadableForRemixIcons(() =>
+const SortDescIcon = importRemixIcon(() =>
   import("remixicon-react/SortDescIcon"),
 );
-const ShareBoxLineIcon = loadableForRemixIcons(() =>
+const ShareBoxLineIcon = importRemixIcon(() =>
   import("remixicon-react/ShareBoxLineIcon"),
 );
-const ShareBoxFillIcon = loadableForRemixIcons(() =>
+const ShareBoxFillIcon = importRemixIcon(() =>
   import("remixicon-react/ShareBoxFillIcon"),
 );
-const ShareForwardIcon = loadableForRemixIcons(() =>
+const ShareForwardIcon = importRemixIcon(() =>
   import("remixicon-react/ShareForwardFillIcon"),
 );
-const Trash = loadableForRemixIcons(() =>
+const Trash = importRemixIcon(() =>
   import("remixicon-react/DeleteBinLineIcon"),
 );
-const UpArrow = loadableForRemixIcons(() =>
+const UpArrow = importRemixIcon(() =>
   import("remixicon-react/ArrowUpSFillIcon"),
 );
-const WarningIcon = loadableForRemixIcons(() =>
+const WarningIcon = importRemixIcon(() =>
   import("remixicon-react/ErrorWarningFillIcon"),
 );
-const WarningLineIcon = loadableForRemixIcons(() =>
+const WarningLineIcon = importRemixIcon(() =>
   import("remixicon-react/ErrorWarningLineIcon"),
 );
-const LoginIcon = loadableForRemixIcons(() =>
+const LoginIcon = importRemixIcon(() =>
   import("remixicon-react/LoginBoxLineIcon"),
 );
-const LogoutIcon = loadableForRemixIcons(() =>
+const LogoutIcon = importRemixIcon(() =>
   import("remixicon-react/LogoutBoxRLineIcon"),
 );
-const ShareLineIcon = loadableForRemixIcons(() =>
+const ShareLineIcon = importRemixIcon(() =>
   import("remixicon-react/ShareLineIcon"),
 );
-const LoaderLineIcon = loadableForRemixIcons(() =>
+const LoaderLineIcon = importRemixIcon(() =>
   import("remixicon-react/LoaderLineIcon"),
 );
-const WidgetIcon = loadableForRemixIcons(() =>
+const WidgetIcon = importRemixIcon(() =>
   import("remixicon-react/FunctionLineIcon"),
 );
-const RefreshLineIcon = loadableForRemixIcons(() =>
+const RefreshLineIcon = importRemixIcon(() =>
   import("remixicon-react/RefreshLineIcon"),
 );
-const GitBranchLineIcon = loadableForRemixIcons(() =>
+const GitBranchLineIcon = importRemixIcon(() =>
   import("remixicon-react/GitBranchLineIcon"),
 );
-const EditBoxLineIcon = loadableForRemixIcons(() =>
+const EditBoxLineIcon = importRemixIcon(() =>
   import("remixicon-react/EditBoxLineIcon"),
 );
-const StarLineIcon = loadableForRemixIcons(() =>
+const StarLineIcon = importRemixIcon(() =>
   import("remixicon-react/StarLineIcon"),
 );
-const StarFillIcon = loadableForRemixIcons(() =>
+const StarFillIcon = importRemixIcon(() =>
   import("remixicon-react/StarFillIcon"),
 );
-const Settings2LineIcon = loadableForRemixIcons(() =>
+const Settings2LineIcon = importRemixIcon(() =>
   import("remixicon-react/Settings2LineIcon"),
 );
-const DownloadIcon = loadableForRemixIcons(() =>
+const DownloadIcon = importRemixIcon(() =>
   import("remixicon-react/DownloadLineIcon"),
 );
-const UploadCloud2LineIcon = loadableForRemixIcons(() =>
+const UploadCloud2LineIcon = importRemixIcon(() =>
   import("remixicon-react/UploadCloud2LineIcon"),
 );
-const DownloadLineIcon = loadableForRemixIcons(() =>
+const DownloadLineIcon = importRemixIcon(() =>
   import("remixicon-react/DownloadLineIcon"),
 );
-const UploadLineIcon = loadableForRemixIcons(() =>
+const UploadLineIcon = importRemixIcon(() =>
   import("remixicon-react/UploadLineIcon"),
 );
-const FileListLineIcon = loadableForRemixIcons(() =>
+const FileListLineIcon = importRemixIcon(() =>
   import("remixicon-react/FileListLineIcon"),
 );
-const HamburgerIcon = loadableForRemixIcons(() =>
+const HamburgerIcon = importRemixIcon(() =>
   import("remixicon-react/MenuLineIcon"),
 );
-const MagicLineIcon = loadableForRemixIcons(() =>
+const MagicLineIcon = importRemixIcon(() =>
   import("remixicon-react/MagicLineIcon"),
 );
-const UserHeartLineIcon = loadableForRemixIcons(() =>
+const UserHeartLineIcon = importRemixIcon(() =>
   import("remixicon-react/UserHeartLineIcon"),
 );
-const DvdLineIcon = loadableForRemixIcons(() =>
+const DvdLineIcon = importRemixIcon(() =>
   import("remixicon-react/DvdLineIcon"),
 );
-const Group2LineIcon = loadableForRemixIcons(() =>
+const Group2LineIcon = importRemixIcon(() =>
   import("remixicon-react/Group2LineIcon"),
 );
-const CodeViewIcon = loadableForRemixIcons(() =>
+const CodeViewIcon = importRemixIcon(() =>
   import("remixicon-react/CodeViewIcon"),
 );
-const GroupLineIcon = loadableForRemixIcons(() =>
+const GroupLineIcon = importRemixIcon(() =>
   import("remixicon-react/GroupLineIcon"),
 );
-const ArrowRightUpLineIcon = loadableForRemixIcons(() =>
+const ArrowRightUpLineIcon = importRemixIcon(() =>
   import("remixicon-react/ArrowRightUpLineIcon"),
 );
-const MailCheckLineIcon = loadableForRemixIcons(() =>
+const MailCheckLineIcon = importRemixIcon(() =>
   import("remixicon-react/MailCheckLineIcon"),
 );
-const UserFollowLineIcon = loadableForRemixIcons(() =>
+const UserFollowLineIcon = importRemixIcon(() =>
   import("remixicon-react/UserFollowLineIcon"),
 );
-const AddBoxLineIcon = loadableForRemixIcons(() =>
+const AddBoxLineIcon = importRemixIcon(() =>
   import("remixicon-react/AddBoxLineIcon"),
 );
-const ArrowRightSFillIcon = loadableForRemixIcons(() =>
+const ArrowRightSFillIcon = importRemixIcon(() =>
   import("remixicon-react/ArrowRightSFillIcon"),
 );
-const ArrowDownSFillIcon = loadableForRemixIcons(() =>
+const ArrowDownSFillIcon = importRemixIcon(() =>
   import("remixicon-react/ArrowDownSFillIcon"),
 );
-const MailLineIcon = loadableForRemixIcons(() =>
+const MailLineIcon = importRemixIcon(() =>
   import("remixicon-react/MailLineIcon"),
 );
-const LockPasswordLineIcon = loadableForRemixIcons(() =>
+const LockPasswordLineIcon = importRemixIcon(() =>
   import("remixicon-react/LockPasswordLineIcon"),
 );
-const Timer2LineIcon = loadableForRemixIcons(() =>
+const Timer2LineIcon = importRemixIcon(() =>
   import("remixicon-react/Timer2LineIcon"),
 );
-const MapPin2LineIcon = loadableForRemixIcons(() =>
+const MapPin2LineIcon = importRemixIcon(() =>
   import("remixicon-react/MapPin2LineIcon"),
 );
-const User3LineIcon = loadableForRemixIcons(() =>
+const User3LineIcon = importRemixIcon(() =>
   import("remixicon-react/User3LineIcon"),
 );
-const User2LineIcon = loadableForRemixIcons(() =>
+const User2LineIcon = importRemixIcon(() =>
   import("remixicon-react/User2LineIcon"),
 );
-const Key2LineIcon = loadableForRemixIcons(() =>
+const Key2LineIcon = importRemixIcon(() =>
   import("remixicon-react/Key2LineIcon"),
 );
-const FileList2LineIcon = loadableForRemixIcons(() =>
+const FileList2LineIcon = importRemixIcon(() =>
   import("remixicon-react/FileList2LineIcon"),
 );
-const Lock2LineIcon = loadableForRemixIcons(() =>
+const Lock2LineIcon = importRemixIcon(() =>
   import("remixicon-react/Lock2LineIcon"),
 );
-const SearchEyeLineIcon = loadableForRemixIcons(() =>
+const SearchEyeLineIcon = importRemixIcon(() =>
   import("remixicon-react/SearchEyeLineIcon"),
 );
-const AlertLineIcon = loadableForRemixIcons(() =>
+const AlertLineIcon = importRemixIcon(() =>
   import("remixicon-react/AlertLineIcon"),
 );
-const SettingsLineIcon = loadableForRemixIcons(() =>
+const SettingsLineIcon = importRemixIcon(() =>
   import("remixicon-react/SettingsLineIcon"),
 );
-const LockUnlockLineIcon = loadableForRemixIcons(() =>
+const LockUnlockLineIcon = importRemixIcon(() =>
   import("remixicon-react/LockUnlockLineIcon"),
 );
-const PantoneLineIcon = loadableForRemixIcons(() =>
+const PantoneLineIcon = importRemixIcon(() =>
   import("remixicon-react/PantoneLineIcon"),
 );
-const QuestionFillIcon = loadableForRemixIcons(() =>
+const QuestionFillIcon = importRemixIcon(() =>
   import("remixicon-react/QuestionFillIcon"),
 );
-const QuestionLineIcon = loadableForRemixIcons(() =>
+const QuestionLineIcon = importRemixIcon(() =>
   import("remixicon-react/QuestionLineIcon"),
 );
-const UserSharedLineIcon = loadableForRemixIcons(() =>
+const UserSharedLineIcon = importRemixIcon(() =>
   import("remixicon-react/UserSharedLineIcon"),
 );
-const UserReceived2LineIcon = loadableForRemixIcons(() =>
+const UserReceived2LineIcon = importRemixIcon(() =>
   import("remixicon-react/UserReceived2LineIcon"),
 );
-const UserAddLineIcon = loadableForRemixIcons(() =>
+const UserAddLineIcon = importRemixIcon(() =>
   import("remixicon-react/UserAddLineIcon"),
 );
-const UserUnfollowLineIcon = loadableForRemixIcons(() =>
+const UserUnfollowLineIcon = importRemixIcon(() =>
   import("remixicon-react/UserUnfollowLineIcon"),
 );
-const DeleteRowIcon = loadableForRemixIcons(() =>
+const DeleteRowIcon = importRemixIcon(() =>
   import("remixicon-react/DeleteRowIcon"),
 );
-const ArrowUpLineIcon = loadableForRemixIcons(() =>
+const ArrowUpLineIcon = importRemixIcon(() =>
   import("remixicon-react/ArrowUpLineIcon"),
 );
-const MoneyDollarCircleLineIcon = loadableForRemixIcons(() =>
+const MoneyDollarCircleLineIcon = importRemixIcon(() =>
   import("remixicon-react/MoneyDollarCircleLineIcon"),
 );
 

--- a/packages/design-system-old/src/Icon/index.tsx
+++ b/packages/design-system-old/src/Icon/index.tsx
@@ -5,190 +5,517 @@ import { Classes } from "Constants/classes";
 import { noop } from "lodash";
 import Spinner from "Spinner";
 import { ControlIcons } from "ControlIcons";
+import { loadableForRemixIcons, loadableForSvg } from "utils/icon-loadables";
 
-import { ReactComponent as BookLineIcon } from "../assets/icons/ads/book-open-line.svg";
-import { ReactComponent as BugIcon } from "../assets/icons/ads/bug.svg";
-import { ReactComponent as CancelIcon } from "../assets/icons/ads/cancel.svg";
-import { ReactComponent as CrossIcon } from "../assets/icons/ads/cross.svg";
-import { ReactComponent as Fork2Icon } from "../assets/icons/ads/fork-2.svg";
-import { ReactComponent as OpenIcon } from "../assets/icons/ads/open.svg";
-import { ReactComponent as UserIcon } from "../assets/icons/ads/user.svg";
-import { ReactComponent as GeneralIcon } from "../assets/icons/ads/general.svg";
-import { ReactComponent as BillingIcon } from "../assets/icons/ads/billing.svg";
-import { ReactComponent as ErrorIcon } from "../assets/icons/ads/error.svg";
-import { ReactComponent as ShineIcon } from "../assets/icons/ads/shine.svg";
-import { ReactComponent as SuccessIcon } from "../assets/icons/ads/success.svg";
-import { ReactComponent as CloseIcon } from "../assets/icons/ads/close.svg";
-import { ReactComponent as WarningTriangleIcon } from "../assets/icons/ads/warning-triangle.svg";
-import { ReactComponent as ShareIcon2 } from "../assets/icons/ads/share-2.svg";
-import { ReactComponent as InviteUserIcon } from "../assets/icons/ads/invite-users.svg";
-import { ReactComponent as ManageIcon } from "../assets/icons/ads/manage.svg";
-import { ReactComponent as ArrowLeft } from "../assets/icons/ads/arrow-left.svg";
-import { ReactComponent as ChevronLeft } from "../assets/icons/ads/chevron_left.svg";
-import { ReactComponent as LinkIcon } from "../assets/icons/ads/link.svg";
-import { ReactComponent as NoResponseIcon } from "../assets/icons/ads/no-response.svg";
-import { ReactComponent as LightningIcon } from "../assets/icons/ads/lightning.svg";
-import { ReactComponent as TrendingFlat } from "../assets/icons/ads/trending-flat.svg";
-import { ReactComponent as PlayIcon } from "../assets/icons/ads/play.svg";
-import { ReactComponent as DesktopIcon } from "../assets/icons/ads/desktop.svg";
-import { ReactComponent as WandIcon } from "../assets/icons/ads/wand.svg";
-import { ReactComponent as MobileIcon } from "../assets/icons/ads/mobile.svg";
-import { ReactComponent as TabletIcon } from "../assets/icons/ads/tablet.svg";
-import { ReactComponent as TabletLandscapeIcon } from "../assets/icons/ads/tablet-landscape.svg";
-import { ReactComponent as FluidIcon } from "../assets/icons/ads/fluid.svg";
-import { ReactComponent as CardContextMenu } from "../assets/icons/ads/card-context-menu.svg";
-import { ReactComponent as SendButton } from "../assets/icons/comments/send-button.svg";
-import { ReactComponent as Pin } from "../assets/icons/comments/pin.svg";
-import { ReactComponent as TrashOutline } from "../assets/icons/form/trash.svg";
-import { ReactComponent as ReadPin } from "../assets/icons/comments/read-pin.svg";
-import { ReactComponent as UnreadPin } from "../assets/icons/comments/unread-pin.svg";
-import { ReactComponent as Chat } from "../assets/icons/comments/chat.svg";
-import { ReactComponent as Unpin } from "../assets/icons/comments/unpinIcon.svg";
-import { ReactComponent as Reaction } from "../assets/icons/comments/reaction.svg";
-import { ReactComponent as Reaction2 } from "../assets/icons/comments/reaction-2.svg";
-import { ReactComponent as Upload } from "../assets/icons/ads/upload.svg";
-import { ReactComponent as ArrowForwardIcon } from "../assets/icons/control/arrow_forward.svg";
-import { ReactComponent as DoubleArrowRightIcon } from "../assets/icons/ads/double-arrow-right.svg";
-import { ReactComponent as CapSolidIcon } from "../assets/icons/control/cap_solid.svg";
-import { ReactComponent as CapDotIcon } from "../assets/icons/control/cap_dot.svg";
-import { ReactComponent as LineDottedIcon } from "../assets/icons/control/line_dotted.svg";
-import { ReactComponent as LineDashedIcon } from "../assets/icons/control/line_dashed.svg";
-import { ReactComponent as TableIcon } from "../assets/icons/ads/tables.svg";
-import { ReactComponent as ColumnIcon } from "../assets/icons/ads/column.svg";
-import { ReactComponent as GearIcon } from "../assets/icons/ads/gear.svg";
-import { ReactComponent as UserV2Icon } from "../assets/icons/ads/user-v2.svg";
-import { ReactComponent as SupportIcon } from "../assets/icons/ads/support.svg";
-import { ReactComponent as Snippet } from "../assets/icons/ads/snippet.svg";
-import { ReactComponent as WorkspaceIcon } from "../assets/icons/ads/workspaceIcon.svg";
-import { ReactComponent as SettingIcon } from "../assets/icons/control/settings.svg";
-import { ReactComponent as DropdownIcon } from "../assets/icons/ads/dropdown.svg";
-import { ReactComponent as ChatIcon } from "../assets/icons/ads/app-icons/chat.svg";
-import { ReactComponent as JsIcon } from "../assets/icons/ads/js.svg";
-import { ReactComponent as ExecuteIcon } from "../assets/icons/ads/execute.svg";
-import { ReactComponent as PackageIcon } from "../assets/icons/ads/package.svg";
+const BookLineIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/book-open-line.svg"),
+);
+const BugIcon = loadableForSvg(() => import("../assets/icons/ads/bug.svg"));
+const CancelIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/cancel.svg"),
+);
+const CrossIcon = loadableForSvg(() => import("../assets/icons/ads/cross.svg"));
+const Fork2Icon = loadableForSvg(() =>
+  import("../assets/icons/ads/fork-2.svg"),
+);
+const OpenIcon = loadableForSvg(() => import("../assets/icons/ads/open.svg"));
+const UserIcon = loadableForSvg(() => import("../assets/icons/ads/user.svg"));
+const GeneralIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/general.svg"),
+);
+const BillingIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/billing.svg"),
+);
+const ErrorIcon = loadableForSvg(() => import("../assets/icons/ads/error.svg"));
+const ShineIcon = loadableForSvg(() => import("../assets/icons/ads/shine.svg"));
+const SuccessIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/success.svg"),
+);
+const CloseIcon = loadableForSvg(() => import("../assets/icons/ads/close.svg"));
+const WarningTriangleIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/warning-triangle.svg"),
+);
+const ShareIcon2 = loadableForSvg(() =>
+  import("../assets/icons/ads/share-2.svg"),
+);
+const InviteUserIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/invite-users.svg"),
+);
+const ManageIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/manage.svg"),
+);
+const ArrowLeft = loadableForSvg(() =>
+  import("../assets/icons/ads/arrow-left.svg"),
+);
+const ChevronLeft = loadableForSvg(() =>
+  import("../assets/icons/ads/chevron_left.svg"),
+);
+const LinkIcon = loadableForSvg(() => import("../assets/icons/ads/link.svg"));
+const NoResponseIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/no-response.svg"),
+);
+const LightningIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/lightning.svg"),
+);
+const TrendingFlat = loadableForSvg(() =>
+  import("../assets/icons/ads/trending-flat.svg"),
+);
+const PlayIcon = loadableForSvg(() => import("../assets/icons/ads/play.svg"));
+const DesktopIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/desktop.svg"),
+);
+const WandIcon = loadableForSvg(() => import("../assets/icons/ads/wand.svg"));
+const MobileIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/mobile.svg"),
+);
+const TabletIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/tablet.svg"),
+);
+const TabletLandscapeIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/tablet-landscape.svg"),
+);
+const FluidIcon = loadableForSvg(() => import("../assets/icons/ads/fluid.svg"));
+const CardContextMenu = loadableForSvg(() =>
+  import("../assets/icons/ads/card-context-menu.svg"),
+);
+const SendButton = loadableForSvg(() =>
+  import("../assets/icons/comments/send-button.svg"),
+);
+const Pin = loadableForSvg(() => import("../assets/icons/comments/pin.svg"));
+const TrashOutline = loadableForSvg(() =>
+  import("../assets/icons/form/trash.svg"),
+);
+const ReadPin = loadableForSvg(() =>
+  import("../assets/icons/comments/read-pin.svg"),
+);
+const UnreadPin = loadableForSvg(() =>
+  import("../assets/icons/comments/unread-pin.svg"),
+);
+const Chat = loadableForSvg(() => import("../assets/icons/comments/chat.svg"));
+const Unpin = loadableForSvg(() =>
+  import("../assets/icons/comments/unpinIcon.svg"),
+);
+const Reaction = loadableForSvg(() =>
+  import("../assets/icons/comments/reaction.svg"),
+);
+const Reaction2 = loadableForSvg(() =>
+  import("../assets/icons/comments/reaction-2.svg"),
+);
+const Upload = loadableForSvg(() => import("../assets/icons/ads/upload.svg"));
+const ArrowForwardIcon = loadableForSvg(() =>
+  import("../assets/icons/control/arrow_forward.svg"),
+);
+const DoubleArrowRightIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/double-arrow-right.svg"),
+);
+const CapSolidIcon = loadableForSvg(() =>
+  import("../assets/icons/control/cap_solid.svg"),
+);
+const CapDotIcon = loadableForSvg(() =>
+  import("../assets/icons/control/cap_dot.svg"),
+);
+const LineDottedIcon = loadableForSvg(() =>
+  import("../assets/icons/control/line_dotted.svg"),
+);
+const LineDashedIcon = loadableForSvg(() =>
+  import("../assets/icons/control/line_dashed.svg"),
+);
+const TableIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/tables.svg"),
+);
+const ColumnIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/column.svg"),
+);
+const GearIcon = loadableForSvg(() => import("../assets/icons/ads/gear.svg"));
+const UserV2Icon = loadableForSvg(() =>
+  import("../assets/icons/ads/user-v2.svg"),
+);
+const SupportIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/support.svg"),
+);
+const Snippet = loadableForSvg(() => import("../assets/icons/ads/snippet.svg"));
+const WorkspaceIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/workspaceIcon.svg"),
+);
+const SettingIcon = loadableForSvg(() =>
+  import("../assets/icons/control/settings.svg"),
+);
+const DropdownIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/dropdown.svg"),
+);
+const ChatIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/app-icons/chat.svg"),
+);
+const JsIcon = loadableForSvg(() => import("../assets/icons/ads/js.svg"));
+const ExecuteIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/execute.svg"),
+);
+const PackageIcon = loadableForSvg(() =>
+  import("../assets/icons/ads/package.svg"),
+);
 
 // remix icons
-import AddMoreIcon from "remixicon-react/AddCircleLineIcon";
-import AddMoreFillIcon from "remixicon-react/AddCircleFillIcon";
-import ArrowLeftRightIcon from "remixicon-react/ArrowLeftRightLineIcon";
-import ArrowDownLineIcon from "remixicon-react/ArrowDownLineIcon";
-import BookIcon from "remixicon-react/BookOpenLineIcon";
-import BugLineIcon from "remixicon-react/BugLineIcon";
-import ChevronRight from "remixicon-react/ArrowRightSFillIcon";
-import CheckLineIcon from "remixicon-react/CheckLineIcon";
-import CloseLineIcon from "remixicon-react/CloseLineIcon";
-import CloseCircleIcon from "remixicon-react/CloseCircleFillIcon";
-import CloudOfflineIcon from "remixicon-react/CloudOffLineIcon";
-import CommentContextMenu from "remixicon-react/More2FillIcon";
-import More2FillIcon from "remixicon-react/More2FillIcon";
-import CompassesLine from "remixicon-react/CompassesLineIcon";
-import ContextMenuIcon from "remixicon-react/MoreFillIcon";
-import CreateNewIcon from "remixicon-react/AddLineIcon";
-import Database2Line from "remixicon-react/Database2LineIcon";
-import DatasourceIcon from "remixicon-react/CloudFillIcon";
-import DeleteBin7 from "remixicon-react/DeleteBin7LineIcon";
-import DiscordIcon from "remixicon-react/DiscordLineIcon";
-import DownArrow from "remixicon-react/ArrowDownSFillIcon";
-import Download from "remixicon-react/DownloadCloud2LineIcon";
-import DuplicateIcon from "remixicon-react/FileCopyLineIcon";
-import EditIcon from "remixicon-react/PencilFillIcon";
-import EditLineIcon from "remixicon-react/EditLineIcon";
-import EditUnderlineIcon from "remixicon-react/EditLineIcon";
-import Emoji from "remixicon-react/EmotionLineIcon";
-import ExpandMore from "remixicon-react/ArrowDownSLineIcon";
-import DownArrowIcon from "remixicon-react/ArrowDownSLineIcon";
-import ExpandLess from "remixicon-react/ArrowUpSLineIcon";
-import EyeOn from "remixicon-react/EyeLineIcon";
-import EyeOff from "remixicon-react/EyeOffLineIcon";
-import FileTransfer from "remixicon-react/FileTransferLineIcon";
-import FileLine from "remixicon-react/FileLineIcon";
-import Filter from "remixicon-react/Filter2FillIcon";
-import ForbidLineIcon from "remixicon-react/ForbidLineIcon";
-import GitMerge from "remixicon-react/GitMergeLineIcon";
-import GitCommit from "remixicon-react/GitCommitLineIcon";
-import GitPullRequst from "remixicon-react/GitPullRequestLineIcon";
-import GlobalLineIcon from "remixicon-react/GlobalLineIcon";
-import GuideIcon from "remixicon-react/GuideFillIcon";
-import HelpIcon from "remixicon-react/QuestionMarkIcon";
-import LightbulbFlashLine from "remixicon-react/LightbulbFlashLineIcon";
-import LinksLineIcon from "remixicon-react/LinksLineIcon";
-import InfoIcon from "remixicon-react/InformationLineIcon";
-import KeyIcon from "remixicon-react/Key2LineIcon";
-import LeftArrowIcon2 from "remixicon-react/ArrowLeftSLineIcon";
-import Link2 from "remixicon-react/LinkIcon";
-import LeftArrowIcon from "remixicon-react/ArrowLeftLineIcon";
-import NewsPaperLine from "remixicon-react/NewspaperLineIcon";
-import OvalCheck from "remixicon-react/CheckboxCircleLineIcon";
-import OvalCheckFill from "remixicon-react/CheckboxCircleFillIcon";
-import Pin3 from "remixicon-react/Pushpin2FillIcon";
-import PlayCircleLineIcon from "remixicon-react/PlayCircleLineIcon";
-import QueryIcon from "remixicon-react/CodeSSlashLineIcon";
-import RemoveIcon from "remixicon-react/SubtractLineIcon";
-import RightArrowIcon from "remixicon-react/ArrowRightLineIcon";
-import RightArrowIcon2 from "remixicon-react/ArrowRightSLineIcon";
-import RocketIcon from "remixicon-react/RocketLineIcon";
-import SearchIcon from "remixicon-react/SearchLineIcon";
-import SortAscIcon from "remixicon-react/SortAscIcon"; 
-import SortDescIcon from "remixicon-react/SortDescIcon"; 
-import ShareBoxLineIcon from "remixicon-react/ShareBoxLineIcon";
-import ShareBoxFillIcon from "remixicon-react/ShareBoxFillIcon";
-import ShareForwardIcon from "remixicon-react/ShareForwardFillIcon";
-import Trash from "remixicon-react/DeleteBinLineIcon";
-import UpArrow from "remixicon-react/ArrowUpSFillIcon";
-import WarningIcon from "remixicon-react/ErrorWarningFillIcon";
-import WarningLineIcon from "remixicon-react/ErrorWarningLineIcon";
-import LoginIcon from "remixicon-react/LoginBoxLineIcon";
-import LogoutIcon from "remixicon-react/LogoutBoxRLineIcon";
-import ShareLineIcon from "remixicon-react/ShareLineIcon";
-import LoaderLineIcon from "remixicon-react/LoaderLineIcon";
-import WidgetIcon from "remixicon-react/FunctionLineIcon";
-import RefreshLineIcon from "remixicon-react/RefreshLineIcon";
-import GitBranchLineIcon from "remixicon-react/GitBranchLineIcon";
-import EditBoxLineIcon from "remixicon-react/EditBoxLineIcon";
-import StarLineIcon from "remixicon-react/StarLineIcon";
-import StarFillIcon from "remixicon-react/StarFillIcon";
-import Settings2LineIcon from "remixicon-react/Settings2LineIcon";
-import DownloadIcon from "remixicon-react/DownloadLineIcon";
-import UploadCloud2LineIcon from "remixicon-react/UploadCloud2LineIcon";
-import DownloadLineIcon from "remixicon-react/DownloadLineIcon";
-import UploadLineIcon from "remixicon-react/UploadLineIcon";
-import FileListLineIcon from "remixicon-react/FileListLineIcon";
-import HamburgerIcon from "remixicon-react/MenuLineIcon";
-import MagicLineIcon from "remixicon-react/MagicLineIcon";
-import UserHeartLineIcon from "remixicon-react/UserHeartLineIcon";
-import DvdLineIcon from "remixicon-react/DvdLineIcon";
-import Group2LineIcon from "remixicon-react/Group2LineIcon";
-import CodeViewIcon from "remixicon-react/CodeViewIcon";
-import GroupLineIcon from "remixicon-react/GroupLineIcon";
-import ArrowRightUpLineIcon from "remixicon-react/ArrowRightUpLineIcon";
-import MailCheckLineIcon from "remixicon-react/MailCheckLineIcon";
-import UserFollowLineIcon from "remixicon-react/UserFollowLineIcon";
-import AddBoxLineIcon from "remixicon-react/AddBoxLineIcon";
-import ArrowRightSFillIcon from "remixicon-react/ArrowRightSFillIcon";
-import ArrowDownSFillIcon from "remixicon-react/ArrowDownSFillIcon";
-import MailLineIcon from "remixicon-react/MailLineIcon";
-import LockPasswordLineIcon from "remixicon-react/LockPasswordLineIcon";
-import Timer2LineIcon from "remixicon-react/Timer2LineIcon";
-import MapPin2LineIcon from "remixicon-react/MapPin2LineIcon";
-import User3LineIcon from "remixicon-react/User3LineIcon";
-import User2LineIcon from "remixicon-react/User2LineIcon";
-import Key2LineIcon from "remixicon-react/Key2LineIcon";
-import FileList2LineIcon from "remixicon-react/FileList2LineIcon";
-import Lock2LineIcon from "remixicon-react/Lock2LineIcon";
-import SearchEyeLineIcon from "remixicon-react/SearchEyeLineIcon";
-import AlertLineIcon from "remixicon-react/AlertLineIcon";
-import SettingsLineIcon from "remixicon-react/SettingsLineIcon";
-import LockUnlockLineIcon from "remixicon-react/LockUnlockLineIcon";
-import PantoneLineIcon from "remixicon-react/PantoneLineIcon";
-import QuestionFillIcon from "remixicon-react/QuestionFillIcon";
-import QuestionLineIcon from "remixicon-react/QuestionLineIcon";
-import UserSharedLineIcon from "remixicon-react/UserSharedLineIcon";
-import UserReceived2LineIcon from "remixicon-react/UserReceived2LineIcon";
-import UserAddLineIcon from "remixicon-react/UserAddLineIcon";
-import UserUnfollowLineIcon from "remixicon-react/UserUnfollowLineIcon";
-import DeleteRowIcon from "remixicon-react/DeleteRowIcon";
-import ArrowUpLineIcon from "remixicon-react/ArrowUpLineIcon";
-import MoneyDollarCircleLineIcon from "remixicon-react/MoneyDollarCircleLineIcon";
+const AddMoreIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/AddCircleLineIcon"),
+);
+const AddMoreFillIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/AddCircleFillIcon"),
+);
+const ArrowLeftRightIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/ArrowLeftRightLineIcon"),
+);
+const ArrowDownLineIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/ArrowDownLineIcon"),
+);
+const BookIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/BookOpenLineIcon"),
+);
+const BugLineIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/BugLineIcon"),
+);
+const ChevronRight = loadableForRemixIcons(() =>
+  import("remixicon-react/ArrowRightSFillIcon"),
+);
+const CheckLineIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/CheckLineIcon"),
+);
+const CloseLineIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/CloseLineIcon"),
+);
+const CloseCircleIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/CloseCircleFillIcon"),
+);
+const CloudOfflineIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/CloudOffLineIcon"),
+);
+const CommentContextMenu = loadableForRemixIcons(() =>
+  import("remixicon-react/More2FillIcon"),
+);
+const More2FillIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/More2FillIcon"),
+);
+const CompassesLine = loadableForRemixIcons(() =>
+  import("remixicon-react/CompassesLineIcon"),
+);
+const ContextMenuIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/MoreFillIcon"),
+);
+const CreateNewIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/AddLineIcon"),
+);
+const Database2Line = loadableForRemixIcons(() =>
+  import("remixicon-react/Database2LineIcon"),
+);
+const DatasourceIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/CloudFillIcon"),
+);
+const DeleteBin7 = loadableForRemixIcons(() =>
+  import("remixicon-react/DeleteBin7LineIcon"),
+);
+const DiscordIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/DiscordLineIcon"),
+);
+const DownArrow = loadableForRemixIcons(() =>
+  import("remixicon-react/ArrowDownSFillIcon"),
+);
+const Download = loadableForRemixIcons(() =>
+  import("remixicon-react/DownloadCloud2LineIcon"),
+);
+const DuplicateIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/FileCopyLineIcon"),
+);
+const EditIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/PencilFillIcon"),
+);
+const EditLineIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/EditLineIcon"),
+);
+const EditUnderlineIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/EditLineIcon"),
+);
+const Emoji = loadableForRemixIcons(() =>
+  import("remixicon-react/EmotionLineIcon"),
+);
+const ExpandMore = loadableForRemixIcons(() =>
+  import("remixicon-react/ArrowDownSLineIcon"),
+);
+const DownArrowIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/ArrowDownSLineIcon"),
+);
+const ExpandLess = loadableForRemixIcons(() =>
+  import("remixicon-react/ArrowUpSLineIcon"),
+);
+const EyeOn = loadableForRemixIcons(() =>
+  import("remixicon-react/EyeLineIcon"),
+);
+const EyeOff = loadableForRemixIcons(() =>
+  import("remixicon-react/EyeOffLineIcon"),
+);
+const FileTransfer = loadableForRemixIcons(() =>
+  import("remixicon-react/FileTransferLineIcon"),
+);
+const FileLine = loadableForRemixIcons(() =>
+  import("remixicon-react/FileLineIcon"),
+);
+const Filter = loadableForRemixIcons(() =>
+  import("remixicon-react/Filter2FillIcon"),
+);
+const ForbidLineIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/ForbidLineIcon"),
+);
+const GitMerge = loadableForRemixIcons(() =>
+  import("remixicon-react/GitMergeLineIcon"),
+);
+const GitCommit = loadableForRemixIcons(() =>
+  import("remixicon-react/GitCommitLineIcon"),
+);
+const GitPullRequst = loadableForRemixIcons(() =>
+  import("remixicon-react/GitPullRequestLineIcon"),
+);
+const GlobalLineIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/GlobalLineIcon"),
+);
+const GuideIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/GuideFillIcon"),
+);
+const HelpIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/QuestionMarkIcon"),
+);
+const LightbulbFlashLine = loadableForRemixIcons(() =>
+  import("remixicon-react/LightbulbFlashLineIcon"),
+);
+const LinksLineIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/LinksLineIcon"),
+);
+const InfoIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/InformationLineIcon"),
+);
+const KeyIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/Key2LineIcon"),
+);
+const LeftArrowIcon2 = loadableForRemixIcons(() =>
+  import("remixicon-react/ArrowLeftSLineIcon"),
+);
+const Link2 = loadableForRemixIcons(() => import("remixicon-react/LinkIcon"));
+const LeftArrowIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/ArrowLeftLineIcon"),
+);
+const NewsPaperLine = loadableForRemixIcons(() =>
+  import("remixicon-react/NewspaperLineIcon"),
+);
+const OvalCheck = loadableForRemixIcons(() =>
+  import("remixicon-react/CheckboxCircleLineIcon"),
+);
+const OvalCheckFill = loadableForRemixIcons(() =>
+  import("remixicon-react/CheckboxCircleFillIcon"),
+);
+const Pin3 = loadableForRemixIcons(() =>
+  import("remixicon-react/Pushpin2FillIcon"),
+);
+const PlayCircleLineIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/PlayCircleLineIcon"),
+);
+const QueryIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/CodeSSlashLineIcon"),
+);
+const RemoveIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/SubtractLineIcon"),
+);
+const RightArrowIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/ArrowRightLineIcon"),
+);
+const RightArrowIcon2 = loadableForRemixIcons(() =>
+  import("remixicon-react/ArrowRightSLineIcon"),
+);
+const RocketIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/RocketLineIcon"),
+);
+const SearchIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/SearchLineIcon"),
+);
+const SortAscIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/SortAscIcon"),
+);
+const SortDescIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/SortDescIcon"),
+);
+const ShareBoxLineIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/ShareBoxLineIcon"),
+);
+const ShareBoxFillIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/ShareBoxFillIcon"),
+);
+const ShareForwardIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/ShareForwardFillIcon"),
+);
+const Trash = loadableForRemixIcons(() =>
+  import("remixicon-react/DeleteBinLineIcon"),
+);
+const UpArrow = loadableForRemixIcons(() =>
+  import("remixicon-react/ArrowUpSFillIcon"),
+);
+const WarningIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/ErrorWarningFillIcon"),
+);
+const WarningLineIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/ErrorWarningLineIcon"),
+);
+const LoginIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/LoginBoxLineIcon"),
+);
+const LogoutIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/LogoutBoxRLineIcon"),
+);
+const ShareLineIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/ShareLineIcon"),
+);
+const LoaderLineIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/LoaderLineIcon"),
+);
+const WidgetIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/FunctionLineIcon"),
+);
+const RefreshLineIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/RefreshLineIcon"),
+);
+const GitBranchLineIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/GitBranchLineIcon"),
+);
+const EditBoxLineIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/EditBoxLineIcon"),
+);
+const StarLineIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/StarLineIcon"),
+);
+const StarFillIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/StarFillIcon"),
+);
+const Settings2LineIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/Settings2LineIcon"),
+);
+const DownloadIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/DownloadLineIcon"),
+);
+const UploadCloud2LineIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/UploadCloud2LineIcon"),
+);
+const DownloadLineIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/DownloadLineIcon"),
+);
+const UploadLineIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/UploadLineIcon"),
+);
+const FileListLineIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/FileListLineIcon"),
+);
+const HamburgerIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/MenuLineIcon"),
+);
+const MagicLineIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/MagicLineIcon"),
+);
+const UserHeartLineIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/UserHeartLineIcon"),
+);
+const DvdLineIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/DvdLineIcon"),
+);
+const Group2LineIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/Group2LineIcon"),
+);
+const CodeViewIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/CodeViewIcon"),
+);
+const GroupLineIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/GroupLineIcon"),
+);
+const ArrowRightUpLineIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/ArrowRightUpLineIcon"),
+);
+const MailCheckLineIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/MailCheckLineIcon"),
+);
+const UserFollowLineIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/UserFollowLineIcon"),
+);
+const AddBoxLineIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/AddBoxLineIcon"),
+);
+const ArrowRightSFillIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/ArrowRightSFillIcon"),
+);
+const ArrowDownSFillIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/ArrowDownSFillIcon"),
+);
+const MailLineIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/MailLineIcon"),
+);
+const LockPasswordLineIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/LockPasswordLineIcon"),
+);
+const Timer2LineIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/Timer2LineIcon"),
+);
+const MapPin2LineIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/MapPin2LineIcon"),
+);
+const User3LineIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/User3LineIcon"),
+);
+const User2LineIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/User2LineIcon"),
+);
+const Key2LineIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/Key2LineIcon"),
+);
+const FileList2LineIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/FileList2LineIcon"),
+);
+const Lock2LineIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/Lock2LineIcon"),
+);
+const SearchEyeLineIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/SearchEyeLineIcon"),
+);
+const AlertLineIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/AlertLineIcon"),
+);
+const SettingsLineIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/SettingsLineIcon"),
+);
+const LockUnlockLineIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/LockUnlockLineIcon"),
+);
+const PantoneLineIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/PantoneLineIcon"),
+);
+const QuestionFillIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/QuestionFillIcon"),
+);
+const QuestionLineIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/QuestionLineIcon"),
+);
+const UserSharedLineIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/UserSharedLineIcon"),
+);
+const UserReceived2LineIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/UserReceived2LineIcon"),
+);
+const UserAddLineIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/UserAddLineIcon"),
+);
+const UserUnfollowLineIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/UserUnfollowLineIcon"),
+);
+const DeleteRowIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/DeleteRowIcon"),
+);
+const ArrowUpLineIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/ArrowUpLineIcon"),
+);
+const MoneyDollarCircleLineIcon = loadableForRemixIcons(() =>
+  import("remixicon-react/MoneyDollarCircleLineIcon"),
+);
 
 export enum IconSize {
   XXS = "extraExtraSmall",

--- a/packages/design-system-old/src/LabelWithTooltip/index.tsx
+++ b/packages/design-system-old/src/LabelWithTooltip/index.tsx
@@ -6,7 +6,11 @@ import { LabelPosition } from "Types/common";
 import { FontStyleTypes } from "Constants/typography";
 import Tooltip from "Tooltip";
 import { IconWrapper } from "Icon";
-import { ReactComponent as HelpIcon } from "../assets/icons/control/help.svg";
+import { loadableForSvg } from "Utils/icon-loadables";
+
+const HelpIcon = loadableForSvg(() =>
+  import("../assets/icons/control/help.svg"),
+);
 
 export interface LabelWithTooltipProps {
   alignment?: Alignment;

--- a/packages/design-system-old/src/LabelWithTooltip/index.tsx
+++ b/packages/design-system-old/src/LabelWithTooltip/index.tsx
@@ -6,11 +6,9 @@ import { LabelPosition } from "Types/common";
 import { FontStyleTypes } from "Constants/typography";
 import Tooltip from "Tooltip";
 import { IconWrapper } from "Icon";
-import { loadableForSvg } from "Utils/icon-loadables";
+import { importSvg } from "Utils/icon-loadables";
 
-const HelpIcon = loadableForSvg(() =>
-  import("../assets/icons/control/help.svg"),
-);
+const HelpIcon = importSvg(() => import("../assets/icons/control/help.svg"));
 
 export interface LabelWithTooltipProps {
   alignment?: Alignment;

--- a/packages/design-system-old/src/SearchComponent/index.tsx
+++ b/packages/design-system-old/src/SearchComponent/index.tsx
@@ -2,9 +2,9 @@ import React from "react";
 import styled from "styled-components";
 import { InputGroup } from "@blueprintjs/core";
 import { debounce } from "lodash";
-import { loadableForSvg } from "Utils/icon-loadables";
+import { importSvg } from "Utils/icon-loadables";
 
-const CrossIcon = loadableForSvg(() => import("../assets/icons/ads/cross.svg"));
+const CrossIcon = importSvg(() => import("../assets/icons/ads/cross.svg"));
 
 interface SearchProps {
   onSearch: (value: any) => void;

--- a/packages/design-system-old/src/SearchComponent/index.tsx
+++ b/packages/design-system-old/src/SearchComponent/index.tsx
@@ -2,7 +2,9 @@ import React from "react";
 import styled from "styled-components";
 import { InputGroup } from "@blueprintjs/core";
 import { debounce } from "lodash";
-import { ReactComponent as CrossIcon } from "../assets/icons/ads/cross.svg";
+import { loadableForSvg } from "Utils/icon-loadables";
+
+const CrossIcon = loadableForSvg(() => import("../assets/icons/ads/cross.svg"));
 
 interface SearchProps {
   onSearch: (value: any) => void;

--- a/packages/design-system-old/src/Table/index.tsx
+++ b/packages/design-system-old/src/Table/index.tsx
@@ -1,12 +1,18 @@
 import { useTable, useSortBy, useExpanded } from "react-table";
 import React from "react";
 import styled from "styled-components";
-import { ReactComponent as DownArrow } from "../assets/icons/ads/down_arrow.svg";
-import { ReactComponent as UpperArrow } from "../assets/icons/ads/upper_arrow.svg";
 import { Classes } from "Constants/classes";
 import { typography } from "Constants/typography";
 import Spinner from "Spinner";
 import { IconSize } from "Icon";
+import { loadableForSvg } from "Utils/icon-loadables";
+
+const DownArrow = loadableForSvg(() =>
+  import("../assets/icons/ads/down_arrow.svg"),
+);
+const UpperArrow = loadableForSvg(() =>
+  import("../assets/icons/ads/upper_arrow.svg"),
+);
 
 const Styles = styled.div`
   table {

--- a/packages/design-system-old/src/Table/index.tsx
+++ b/packages/design-system-old/src/Table/index.tsx
@@ -5,12 +5,10 @@ import { Classes } from "Constants/classes";
 import { typography } from "Constants/typography";
 import Spinner from "Spinner";
 import { IconSize } from "Icon";
-import { loadableForSvg } from "Utils/icon-loadables";
+import { importSvg } from "Utils/icon-loadables";
 
-const DownArrow = loadableForSvg(() =>
-  import("../assets/icons/ads/down_arrow.svg"),
-);
-const UpperArrow = loadableForSvg(() =>
+const DownArrow = importSvg(() => import("../assets/icons/ads/down_arrow.svg"));
+const UpperArrow = importSvg(() =>
   import("../assets/icons/ads/upper_arrow.svg"),
 );
 

--- a/packages/design-system-old/src/index.ts
+++ b/packages/design-system-old/src/index.ts
@@ -194,3 +194,4 @@ export * from "./constants/typography";
 export * from "./constants/variants";
 export * from "./types/common";
 export * from "./utils/colors";
+export * from "./utils/icon-loadables";

--- a/packages/design-system-old/src/utils/icon-loadables.tsx
+++ b/packages/design-system-old/src/utils/icon-loadables.tsx
@@ -7,7 +7,7 @@ import {
   RemixiconReactIconComponentType,
 } from "remixicon-react";
 
-function loadableForIconImpl(
+function importIconImpl(
   importFn: () => Promise<any>,
   options?: {
     resolveComponent: (m: any) => React.ComponentType;
@@ -28,16 +28,16 @@ function loadableForIconImpl(
   };
 }
 
-export function loadableForSvg(
+export function importSvg(
   importFn: () => Promise<typeof import("*.svg")>,
 ): React.ComponentType<React.SVGProps<SVGSVGElement>> {
-  return loadableForIconImpl(importFn, {
+  return importIconImpl(importFn, {
     resolveComponent: (m: typeof import("*.svg")) => m.ReactComponent,
   });
 }
 
-export function loadableForRemixIcons(
+export function importRemixIcon(
   importFn: () => Promise<{ default: RemixiconReactIconComponentType }>,
 ): React.ComponentType<RemixiconReactIconProps> {
-  return loadableForIconImpl(importFn);
+  return importIconImpl(importFn);
 }

--- a/packages/design-system-old/src/utils/icon-loadables.tsx
+++ b/packages/design-system-old/src/utils/icon-loadables.tsx
@@ -1,19 +1,15 @@
-// IMPORTANT: Please keep this file in sync with packages/design-system/src/Icon/loadables.tsx.
+// IMPORTANT: please keep this file in sync with packages/design-system-old/src/utils/icon-loadables.tsx.
 
-import React from "react";
-import loadable from "@loadable/component";
+import React, { Suspense } from "react";
 import {
   RemixiconReactIconProps,
   RemixiconReactIconComponentType,
 } from "remixicon-react";
 
 function importIconImpl(
-  importFn: () => Promise<any>,
-  options?: {
-    resolveComponent: (m: any) => React.ComponentType;
-  },
+  importFn: () => Promise<{ default: React.ComponentType }>,
 ) {
-  const IconLoader = loadable.lib(importFn, options as any);
+  const Icon = React.lazy(importFn);
 
   return function AppsmithLoadable(props: any) {
     return (
@@ -21,9 +17,9 @@ function importIconImpl(
       // apply even while the full icon is still loading.
       // And passing all props – if the parent component sets `width` or `height`,
       // we want to make sure it’s applied to the loading fallback as well.
-      <IconLoader fallback={<svg {...props} />}>
-        {(Icon: React.ComponentType) => <Icon {...props} />}
-      </IconLoader>
+      <Suspense fallback={<svg {...props} />}>
+        <Icon {...props} />
+      </Suspense>
     );
   };
 }
@@ -31,9 +27,9 @@ function importIconImpl(
 export function importSvg(
   importFn: () => Promise<typeof import("*.svg")>,
 ): React.ComponentType<React.SVGProps<SVGSVGElement>> {
-  return importIconImpl(importFn, {
-    resolveComponent: (m: typeof import("*.svg")) => m.ReactComponent,
-  });
+  return importIconImpl(() =>
+    importFn().then((m) => ({ default: m.ReactComponent })),
+  );
 }
 
 export function importRemixIcon(

--- a/packages/design-system-old/src/utils/icon-loadables.tsx
+++ b/packages/design-system-old/src/utils/icon-loadables.tsx
@@ -1,24 +1,43 @@
+// IMPORTANT: Please keep this file in sync with packages/design-system/src/Icon/loadables.tsx.
+
 import React from "react";
 import loadable from "@loadable/component";
-import { RemixiconReactIconComponentType } from "remixicon-react";
+import {
+  RemixiconReactIconProps,
+  RemixiconReactIconComponentType,
+} from "remixicon-react";
 
-// Using `<svg />` as a loading fallback – to make sure sizes set by <IconWrapper>
-// apply even while the full icon is still loading.
-const LOADING_FALLBACK = <svg />;
+function loadableForIconImpl(
+  importFn: () => Promise<any>,
+  options?: {
+    resolveComponent: (m: any) => React.ComponentType;
+  },
+) {
+  const IconLoader = loadable.lib(importFn, options as any);
+
+  return function AppsmithLoadable(props: any) {
+    return (
+      // Using `<svg />` as a loading fallback – to make sure sizes set by <IconWrapper>
+      // apply even while the full icon is still loading.
+      // And passing all props – if the parent component sets `width` or `height`,
+      // we want to make sure it’s applied to the loading fallback as well.
+      <IconLoader fallback={<svg {...props} />}>
+        {(Icon: React.ComponentType) => <Icon {...props} />}
+      </IconLoader>
+    );
+  };
+}
 
 export function loadableForSvg(
   importFn: () => Promise<typeof import("*.svg")>,
-) {
-  return loadable(importFn, {
-    resolveComponent: (m) => m.ReactComponent,
-    fallback: LOADING_FALLBACK,
+): React.ComponentType<React.SVGProps<SVGSVGElement>> {
+  return loadableForIconImpl(importFn, {
+    resolveComponent: (m: typeof import("*.svg")) => m.ReactComponent,
   });
 }
 
 export function loadableForRemixIcons(
   importFn: () => Promise<{ default: RemixiconReactIconComponentType }>,
-) {
-  return loadable(importFn, {
-    fallback: LOADING_FALLBACK,
-  });
+): React.ComponentType<RemixiconReactIconProps> {
+  return loadableForIconImpl(importFn);
 }

--- a/packages/design-system-old/src/utils/icon-loadables.tsx
+++ b/packages/design-system-old/src/utils/icon-loadables.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import loadable from "@loadable/component";
+import { RemixiconReactIconComponentType } from "remixicon-react";
+
+// Using `<svg />` as a loading fallback – to make sure sizes set by <IconWrapper>
+// apply even while the full icon is still loading.
+const LOADING_FALLBACK = <svg />;
+
+export function loadableForSvg(
+  importFn: () => Promise<typeof import("*.svg")>,
+) {
+  return loadable(importFn, {
+    resolveComponent: (m) => m.ReactComponent,
+    fallback: LOADING_FALLBACK,
+  });
+}
+
+export function loadableForRemixIcons(
+  importFn: () => Promise<{ default: RemixiconReactIconComponentType }>,
+) {
+  return loadable(importFn, {
+    fallback: LOADING_FALLBACK,
+  });
+}

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -35,6 +35,7 @@
     "@storybook/manager-webpack4": "^6.5.15",
     "@storybook/react": "^6.5.15",
     "@svgr/rollup": "^6.5.1",
+    "@types/loadable__component": "^5.13.4",
     "@types/react": "^17.0.2",
     "@types/react-router-dom": "^5.3.3",
     "@types/styled-components": "^5.1.26",
@@ -71,7 +72,7 @@
     "storybook-zeplin": "^1.7.3",
     "styled-components": "^5.3.6",
     "tsconfig-paths-webpack-plugin": "^3.5.2",
-    "typescript": "4.5.5"
+    "typescript": "4.9.5"
   },
   "peerDependencies": {
     "react": "^17.0.2",
@@ -94,6 +95,7 @@
     ]
   },
   "dependencies": {
+    "@loadable/component": "^5.15.3",
     "@radix-ui/react-dialog": "^1.0.2",
     "@radix-ui/react-dropdown-menu": "^2.0.4",
     "@radix-ui/react-tabs": "^1.0.2",

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -95,7 +95,6 @@
     ]
   },
   "dependencies": {
-    "@loadable/component": "^5.15.3",
     "@radix-ui/react-dialog": "^1.0.2",
     "@radix-ui/react-dropdown-menu": "^2.0.4",
     "@radix-ui/react-tabs": "^1.0.2",

--- a/packages/design-system/src/Icon/Icon.provider.tsx
+++ b/packages/design-system/src/Icon/Icon.provider.tsx
@@ -1,249 +1,733 @@
 import React from "react";
-import AddMoreIcon from "remixicon-react/AddCircleLineIcon";
-import AddMoreFillIcon from "remixicon-react/AddCircleFillIcon";
-import ArrowLeftRightIcon from "remixicon-react/ArrowLeftRightLineIcon";
-import ArrowDownLineIcon from "remixicon-react/ArrowDownLineIcon";
-import BookIcon from "remixicon-react/BookOpenLineIcon";
-import BugLineIcon from "remixicon-react/BugLineIcon";
-import ChevronRight from "remixicon-react/ArrowRightSFillIcon";
-import CheckLineIcon from "remixicon-react/CheckLineIcon";
-import CloseLineIcon from "remixicon-react/CloseLineIcon";
-import CloseCircleIcon from "remixicon-react/CloseCircleFillIcon";
-import CloudOfflineIcon from "remixicon-react/CloudOffLineIcon";
-import CommentContextMenu from "remixicon-react/More2FillIcon";
-import More2FillIcon from "remixicon-react/More2FillIcon";
-import CompassesLine from "remixicon-react/CompassesLineIcon";
-import ContextMenuIcon from "remixicon-react/MoreFillIcon";
-import CreateNewIcon from "remixicon-react/AddLineIcon";
-import Database2Line from "remixicon-react/Database2LineIcon";
-import DatasourceIcon from "remixicon-react/CloudFillIcon";
-import DeleteBin7 from "remixicon-react/DeleteBin7LineIcon";
-import DiscordIcon from "remixicon-react/DiscordLineIcon";
-import DownArrow from "remixicon-react/ArrowDownSFillIcon";
-import Download from "remixicon-react/DownloadCloud2LineIcon";
-import DuplicateIcon from "remixicon-react/FileCopyLineIcon";
-import PencilFillIcon from "remixicon-react/PencilFillIcon";
-import EditLineIcon from "remixicon-react/EditLineIcon";
-import EditUnderlineIcon from "remixicon-react/EditLineIcon";
-import Emoji from "remixicon-react/EmotionLineIcon";
-import ExpandMore from "remixicon-react/ArrowDownSLineIcon";
-import DownArrowIcon from "remixicon-react/ArrowDownSLineIcon";
-import ExpandLess from "remixicon-react/ArrowUpSLineIcon";
-import EyeOn from "remixicon-react/EyeLineIcon";
-import EyeOff from "remixicon-react/EyeOffLineIcon";
-import FileTransfer from "remixicon-react/FileTransferLineIcon";
-import FileLine from "remixicon-react/FileLineIcon";
-import Filter from "remixicon-react/Filter2FillIcon";
-import ForbidLineIcon from "remixicon-react/ForbidLineIcon";
-import GitMerge from "remixicon-react/GitMergeLineIcon";
-import GitCommit from "remixicon-react/GitCommitLineIcon";
-import GitPullRequest from "remixicon-react/GitPullRequestLineIcon";
-import GlobalLineIcon from "remixicon-react/GlobalLineIcon";
-import GuideIcon from "remixicon-react/GuideFillIcon";
-import QuestionMarkIcon from "remixicon-react/QuestionMarkIcon";
-import LightbulbFlashLine from "remixicon-react/LightbulbFlashLineIcon";
-import LinksLineIcon from "remixicon-react/LinksLineIcon";
-import InfoIcon from "remixicon-react/InformationLineIcon";
-import KeyIcon from "remixicon-react/Key2LineIcon";
-import LeftArrowIcon2 from "remixicon-react/ArrowLeftSLineIcon";
-import Link2 from "remixicon-react/LinkIcon";
-import LeftArrowIcon from "remixicon-react/ArrowLeftLineIcon";
-import NewsPaperLine from "remixicon-react/NewspaperLineIcon";
-import OvalCheck from "remixicon-react/CheckboxCircleLineIcon";
-import OvalCheckFill from "remixicon-react/CheckboxCircleFillIcon";
-import Pin3 from "remixicon-react/Pushpin2FillIcon";
-import PlayCircleLineIcon from "remixicon-react/PlayCircleLineIcon";
-import QueryIcon from "remixicon-react/CodeSSlashLineIcon";
-import SubtractLine from "remixicon-react/SubtractLineIcon";
-import RightArrowIcon from "remixicon-react/ArrowRightLineIcon";
-import RightArrowIcon2 from "remixicon-react/ArrowRightSLineIcon";
-import RocketIcon from "remixicon-react/RocketLineIcon";
-import SearchIcon from "remixicon-react/SearchLineIcon";
-import SortAscIcon from "remixicon-react/SortAscIcon";
-import SortDescIcon from "remixicon-react/SortDescIcon";
-import ShareBoxLineIcon from "remixicon-react/ShareBoxLineIcon";
-import ShareBoxFillIcon from "remixicon-react/ShareBoxFillIcon";
-import ShareForwardIcon from "remixicon-react/ShareForwardFillIcon";
-import Trash from "remixicon-react/DeleteBinLineIcon";
-import UpArrow from "remixicon-react/ArrowUpSFillIcon";
-import WarningIcon from "remixicon-react/ErrorWarningFillIcon";
-import WarningLineIcon from "remixicon-react/ErrorWarningLineIcon";
-import LoginIcon from "remixicon-react/LoginBoxLineIcon";
-import LogoutIcon from "remixicon-react/LogoutBoxRLineIcon";
-import ShareLineIcon from "remixicon-react/ShareLineIcon";
-import LoaderLineIcon from "remixicon-react/LoaderLineIcon";
-import WidgetIcon from "remixicon-react/FunctionLineIcon";
-import RefreshLineIcon from "remixicon-react/RefreshLineIcon";
-import GitBranchLineIcon from "remixicon-react/GitBranchLineIcon";
-import EditBoxLineIcon from "remixicon-react/EditBoxLineIcon";
-import StarLineIcon from "remixicon-react/StarLineIcon";
-import StarFillIcon from "remixicon-react/StarFillIcon";
-import Settings2LineIcon from "remixicon-react/Settings2LineIcon";
-import DownloadIcon from "remixicon-react/DownloadLineIcon";
-import UploadCloud2LineIcon from "remixicon-react/UploadCloud2LineIcon";
-import DownloadLineIcon from "remixicon-react/DownloadLineIcon";
-import UploadLineIcon from "remixicon-react/UploadLineIcon";
-import FileListLineIcon from "remixicon-react/FileListLineIcon";
-import HamburgerIcon from "remixicon-react/MenuLineIcon";
-import MagicLineIcon from "remixicon-react/MagicLineIcon";
-import UserHeartLineIcon from "remixicon-react/UserHeartLineIcon";
-import DvdLineIcon from "remixicon-react/DvdLineIcon";
-import Group2LineIcon from "remixicon-react/Group2LineIcon";
-import CodeViewIcon from "remixicon-react/CodeViewIcon";
-import GroupLineIcon from "remixicon-react/GroupLineIcon";
-import ArrowRightUpLineIcon from "remixicon-react/ArrowRightUpLineIcon";
-import MailCheckLineIcon from "remixicon-react/MailCheckLineIcon";
-import UserFollowLineIcon from "remixicon-react/UserFollowLineIcon";
-import AddBoxLineIcon from "remixicon-react/AddBoxLineIcon";
-import ArrowRightSFillIcon from "remixicon-react/ArrowRightSFillIcon";
-import ArrowDownSFillIcon from "remixicon-react/ArrowDownSFillIcon";
-import MailLineIcon from "remixicon-react/MailLineIcon";
-import LockPasswordLineIcon from "remixicon-react/LockPasswordLineIcon";
-import Timer2LineIcon from "remixicon-react/Timer2LineIcon";
-import MapPin2LineIcon from "remixicon-react/MapPin2LineIcon";
-import User3LineIcon from "remixicon-react/User3LineIcon";
-import User2LineIcon from "remixicon-react/User2LineIcon";
-import Key2LineIcon from "remixicon-react/Key2LineIcon";
-import FileList2LineIcon from "remixicon-react/FileList2LineIcon";
-import Lock2LineIcon from "remixicon-react/Lock2LineIcon";
-import SearchEyeLineIcon from "remixicon-react/SearchEyeLineIcon";
-import AlertLineIcon from "remixicon-react/AlertLineIcon";
-import SettingsLineIcon from "remixicon-react/SettingsLineIcon";
-import LockUnlockLineIcon from "remixicon-react/LockUnlockLineIcon";
-import PantoneLineIcon from "remixicon-react/PantoneLineIcon";
-import QuestionFillIcon from "remixicon-react/QuestionFillIcon";
-import QuestionLineIcon from "remixicon-react/QuestionLineIcon";
-import UserSharedLineIcon from "remixicon-react/UserSharedLineIcon";
-import UserReceived2LineIcon from "remixicon-react/UserReceived2LineIcon";
-import UserAddLineIcon from "remixicon-react/UserAddLineIcon";
-import UserUnfollowLineIcon from "remixicon-react/UserUnfollowLineIcon";
-import DeleteRowIcon from "remixicon-react/DeleteRowIcon";
-import ArrowUpLineIcon from "remixicon-react/ArrowUpLineIcon";
-import MoneyDollarCircleLineIcon from "remixicon-react/MoneyDollarCircleLineIcon";
-import IncreaseV2Icon from "remixicon-react/AddLineIcon";
-import CopyIcon from "remixicon-react/FileCopyLineIcon";
-import QuestionIcon from "remixicon-react/QuestionLineIcon";
-import SettingsIcon from "remixicon-react/Settings5LineIcon";
-import EyeIcon from "remixicon-react/EyeLineIcon";
-import EyeOffIcon from "remixicon-react/EyeOffLineIcon";
-import CloseIcon from "remixicon-react/CloseLineIcon";
-import SubtractIcon from "remixicon-react/SubtractFillIcon";
-import { ReactComponent as BookLineIcon } from "../__assets__/icons/ads/book-open-line.svg";
-import { ReactComponent as BugIcon } from "../__assets__/icons/ads/bug.svg";
-import { ReactComponent as CancelIcon } from "../__assets__/icons/ads/cancel.svg";
-import { ReactComponent as CrossIcon } from "../__assets__/icons/ads/cross.svg";
-import { ReactComponent as Fork2Icon } from "../__assets__/icons/ads/fork-2.svg";
-import { ReactComponent as OpenIcon } from "../__assets__/icons/ads/open.svg";
-import { ReactComponent as UserIcon } from "../__assets__/icons/ads/user.svg";
-import { ReactComponent as GeneralIcon } from "../__assets__/icons/ads/general.svg";
-import { ReactComponent as BillingIcon } from "../__assets__/icons/ads/billing.svg";
-import { ReactComponent as ErrorIcon } from "../__assets__/icons/ads/error.svg";
-import { ReactComponent as ShineIcon } from "../__assets__/icons/ads/shine.svg";
-import { ReactComponent as SuccessIcon } from "../__assets__/icons/ads/success.svg";
-import { ReactComponent as WarningTriangleIcon } from "../__assets__/icons/ads/warning-triangle.svg";
-import { ReactComponent as ShareIcon2 } from "../__assets__/icons/ads/share-2.svg";
-import { ReactComponent as InviteUserIcon } from "../__assets__/icons/ads/invite-users.svg";
-import { ReactComponent as ManageIcon } from "../__assets__/icons/ads/manage.svg";
-import { ReactComponent as ArrowLeft } from "../__assets__/icons/ads/arrow-left.svg";
-import { ReactComponent as ChevronLeft } from "../__assets__/icons/ads/chevron_left.svg";
-import { ReactComponent as LinkIcon } from "../__assets__/icons/ads/link.svg";
-import { ReactComponent as NoResponseIcon } from "../__assets__/icons/ads/no-response.svg";
-import { ReactComponent as LightningIcon } from "../__assets__/icons/ads/lightning.svg";
-import { ReactComponent as TrendingFlat } from "../__assets__/icons/ads/trending-flat.svg";
-import { ReactComponent as PlayIcon } from "../__assets__/icons/ads/play.svg";
-import { ReactComponent as DesktopIcon } from "../__assets__/icons/ads/desktop.svg";
-import { ReactComponent as WandIcon } from "../__assets__/icons/ads/wand.svg";
-import { ReactComponent as MobileIcon } from "../__assets__/icons/ads/mobile.svg";
-import { ReactComponent as TabletIcon } from "../__assets__/icons/ads/tablet.svg";
-import { ReactComponent as TabletLandscapeIcon } from "../__assets__/icons/ads/tablet-landscape.svg";
-import { ReactComponent as FluidIcon } from "../__assets__/icons/ads/fluid.svg";
-import { ReactComponent as CardContextMenu } from "../__assets__/icons/ads/card-context-menu.svg";
-import { ReactComponent as SendButton } from "../__assets__/icons/comments/send-button.svg";
-import { ReactComponent as Pin } from "../__assets__/icons/comments/pin.svg";
-import { ReactComponent as TrashOutline } from "../__assets__/icons/form/trash.svg";
-import { ReactComponent as ReadPin } from "../__assets__/icons/comments/read-pin.svg";
-import { ReactComponent as UnreadPin } from "../__assets__/icons/comments/unread-pin.svg";
-import { ReactComponent as Chat } from "../__assets__/icons/comments/chat.svg";
-import { ReactComponent as Unpin } from "../__assets__/icons/comments/unpinIcon.svg";
-import { ReactComponent as Reaction } from "../__assets__/icons/comments/reaction.svg";
-import { ReactComponent as Reaction2 } from "../__assets__/icons/comments/reaction-2.svg";
-import { ReactComponent as Upload } from "../__assets__/icons/ads/upload.svg";
-import { ReactComponent as ArrowForwardIcon } from "../__assets__/icons/control/arrow_forward.svg";
-import { ReactComponent as DoubleArrowRightIcon } from "../__assets__/icons/ads/double-arrow-right.svg";
-import { ReactComponent as CapSolidIcon } from "../__assets__/icons/control/cap_solid.svg";
-import { ReactComponent as CapDotIcon } from "../__assets__/icons/control/cap_dot.svg";
-import { ReactComponent as LineDottedIcon } from "../__assets__/icons/control/line_dotted.svg";
-import { ReactComponent as LineDashedIcon } from "../__assets__/icons/control/line_dashed.svg";
-import { ReactComponent as TableIcon } from "../__assets__/icons/ads/tables.svg";
-import { ReactComponent as ColumnIcon } from "../__assets__/icons/ads/column.svg";
-import { ReactComponent as GearIcon } from "../__assets__/icons/ads/gear.svg";
-import { ReactComponent as UserV2Icon } from "../__assets__/icons/ads/user-v2.svg";
-import { ReactComponent as SupportIcon } from "../__assets__/icons/ads/support.svg";
-import { ReactComponent as Snippet } from "../__assets__/icons/ads/snippet.svg";
-import { ReactComponent as WorkspaceIcon } from "../__assets__/icons/ads/workspaceIcon.svg";
-import { ReactComponent as SettingIcon } from "../__assets__/icons/control/settings.svg";
-import { ReactComponent as DropdownIcon } from "../__assets__/icons/ads/dropdown.svg";
-import { ReactComponent as ChatIcon } from "../__assets__/icons/ads/app-icons/chat.svg";
-import { ReactComponent as JsIcon } from "../__assets__/icons/ads/js.svg";
-import { ReactComponent as ExecuteIcon } from "../__assets__/icons/ads/execute.svg";
-import { ReactComponent as PackageIcon } from "../__assets__/icons/ads/package.svg";
-import { ReactComponent as DeleteIcon } from "../__assets__/icons/control/delete.svg";
-import { ReactComponent as MoveIcon } from "../__assets__/icons/control/move.svg";
-import { ReactComponent as EditIcon } from "../__assets__/icons/control/edit.svg";
-import { ReactComponent as ViewIcon } from "../__assets__/icons/control/view.svg";
-import { ReactComponent as MoreVerticalIcon } from "../__assets__/icons/control/more-vertical.svg";
-import { ReactComponent as OverflowMenuIcon } from "../__assets__/icons/menu/overflow-menu.svg";
-import { ReactComponent as JsToggleIcon } from "../__assets__/icons/control/js-toggle.svg";
-import { ReactComponent as IncreaseIcon } from "../__assets__/icons/control/increase.svg";
-import { ReactComponent as DecreaseIcon } from "../__assets__/icons/control/decrease.svg";
-import { ReactComponent as DraggableIcon } from "../__assets__/icons/control/draggable.svg";
-import { ReactComponent as AddCircleIcon } from "../__assets__/icons/control/add-circle.svg";
-import { ReactComponent as HelpIcon } from "../__assets__/icons/control/help.svg";
-import { ReactComponent as CollapseIcon } from "../__assets__/icons/control/collapse.svg";
-import { ReactComponent as PickMyLocationSelectedIcon } from "../__assets__/icons/control/pick-location-selected.svg";
-import { ReactComponent as RemoveIcon } from "../__assets__/icons/control/remove.svg";
-import { ReactComponent as DragIcon } from "../__assets__/icons/control/drag.svg";
-import { ReactComponent as SortIcon } from "../__assets__/icons/control/sort-icon.svg";
-import { ReactComponent as EditWhiteIcon } from "../__assets__/icons/control/edit-white.svg";
-import { ReactComponent as LaunchIcon } from "../__assets__/icons/control/launch.svg";
-import { ReactComponent as BackIcon } from "../__assets__/icons/control/back.svg";
-import { ReactComponent as DeleteColumnIcon } from "../__assets__/icons/control/delete-column.svg";
-import { ReactComponent as BoldFontIcon } from "../__assets__/icons/control/bold.svg";
-import { ReactComponent as UnderlineIcon } from "../__assets__/icons/control/underline.svg";
-import { ReactComponent as ItalicsFontIcon } from "../__assets__/icons/control/italics.svg";
-import { ReactComponent as LeftAlignIcon } from "../__assets__/icons/control/left-align.svg";
-import { ReactComponent as CenterAlignIcon } from "../__assets__/icons/control/center-align.svg";
-import { ReactComponent as RightAlignIcon } from "../__assets__/icons/control/right-align.svg";
-import { ReactComponent as VerticalAlignRight } from "../__assets__/icons/control/align_right.svg";
-import { ReactComponent as VerticalAlignLeft } from "../__assets__/icons/control/align_left.svg";
-import { ReactComponent as VerticalAlignBottom } from "../__assets__/icons/control/vertical_align_bottom.svg";
-import { ReactComponent as VerticalAlignCenter } from "../__assets__/icons/control/vertical_align_center.svg";
-import { ReactComponent as VerticalAlignTop } from "../__assets__/icons/control/vertical_align_top.svg";
-import { ReactComponent as Copy2Icon } from "../__assets__/icons/control/copy2.svg";
-import { ReactComponent as CutIcon } from "../__assets__/icons/control/cut.svg";
-import { ReactComponent as GroupIcon } from "../__assets__/icons/control/group.svg";
-import { ReactComponent as HeadingOneIcon } from "../__assets__/icons/control/heading_1.svg";
-import { ReactComponent as HeadingTwoIcon } from "../__assets__/icons/control/heading_2.svg";
-import { ReactComponent as HeadingThreeIcon } from "../__assets__/icons/control/heading_3.svg";
-import { ReactComponent as ParagraphIcon } from "../__assets__/icons/control/paragraph.svg";
-import { ReactComponent as ParagraphTwoIcon } from "../__assets__/icons/control/paragraph_2.svg";
-import { ReactComponent as BulletsIcon } from "../__assets__/icons/control/bullets.svg";
-import { ReactComponent as DividerCapRightIcon } from "../__assets__/icons/control/divider_cap_right.svg";
-import { ReactComponent as DividerCapLeftIcon } from "../__assets__/icons/control/divider_cap_left.svg";
-import { ReactComponent as DividerCapAllIcon } from "../__assets__/icons/control/divider_cap_all.svg";
-import { ReactComponent as AlignLeftIcon } from "../__assets__/icons/control/align_left.svg";
-import { ReactComponent as AlignRightIcon } from "../__assets__/icons/control/align_right.svg";
-import { ReactComponent as BorderRadiusSharpIcon } from "../__assets__/icons/control/border-radius-sharp.svg";
-import { ReactComponent as BorderRadiusRoundedIcon } from "../__assets__/icons/control/border-radius-rounded.svg";
-import { ReactComponent as BorderRadiusCircleIcon } from "../__assets__/icons/control/border-radius-circle.svg";
-import { ReactComponent as BoxShadowNoneIcon } from "../__assets__/icons/control/box-shadow-none.svg";
-import { ReactComponent as BoxShadowVariant1Icon } from "../__assets__/icons/control/box-shadow-variant1.svg";
-import { ReactComponent as BoxShadowVariant2Icon } from "../__assets__/icons/control/box-shadow-variant2.svg";
-import { ReactComponent as BoxShadowVariant3Icon } from "../__assets__/icons/control/box-shadow-variant3.svg";
-import { ReactComponent as BoxShadowVariant4Icon } from "../__assets__/icons/control/box-shadow-variant4.svg";
-import { ReactComponent as BoxShadowVariant5Icon } from "../__assets__/icons/control/box-shadow-variant5.svg";
 import PlayIconPNG from "../__assets__/icons/control/play-icon.png";
-import { ReactComponent as JsToggleV2 } from "../__assets__/icons/ads/js-toggle-v2.svg";
+import { loadableForRemixIcons, loadableForSvg } from "./loadables";
+
+const AddMoreIcon = loadableForRemixIcons(
+  () => import("remixicon-react/AddCircleLineIcon"),
+);
+const AddMoreFillIcon = loadableForRemixIcons(
+  () => import("remixicon-react/AddCircleFillIcon"),
+);
+const ArrowLeftRightIcon = loadableForRemixIcons(
+  () => import("remixicon-react/ArrowLeftRightLineIcon"),
+);
+const ArrowDownLineIcon = loadableForRemixIcons(
+  () => import("remixicon-react/ArrowDownLineIcon"),
+);
+const BookIcon = loadableForRemixIcons(
+  () => import("remixicon-react/BookOpenLineIcon"),
+);
+const BugLineIcon = loadableForRemixIcons(
+  () => import("remixicon-react/BugLineIcon"),
+);
+const ChevronRight = loadableForRemixIcons(
+  () => import("remixicon-react/ArrowRightSFillIcon"),
+);
+const CheckLineIcon = loadableForRemixIcons(
+  () => import("remixicon-react/CheckLineIcon"),
+);
+const CloseLineIcon = loadableForRemixIcons(
+  () => import("remixicon-react/CloseLineIcon"),
+);
+const CloseCircleIcon = loadableForRemixIcons(
+  () => import("remixicon-react/CloseCircleFillIcon"),
+);
+const CloudOfflineIcon = loadableForRemixIcons(
+  () => import("remixicon-react/CloudOffLineIcon"),
+);
+const CommentContextMenu = loadableForRemixIcons(
+  () => import("remixicon-react/More2FillIcon"),
+);
+const More2FillIcon = loadableForRemixIcons(
+  () => import("remixicon-react/More2FillIcon"),
+);
+const CompassesLine = loadableForRemixIcons(
+  () => import("remixicon-react/CompassesLineIcon"),
+);
+const ContextMenuIcon = loadableForRemixIcons(
+  () => import("remixicon-react/MoreFillIcon"),
+);
+const CreateNewIcon = loadableForRemixIcons(
+  () => import("remixicon-react/AddLineIcon"),
+);
+const Database2Line = loadableForRemixIcons(
+  () => import("remixicon-react/Database2LineIcon"),
+);
+const DatasourceIcon = loadableForRemixIcons(
+  () => import("remixicon-react/CloudFillIcon"),
+);
+const DeleteBin7 = loadableForRemixIcons(
+  () => import("remixicon-react/DeleteBin7LineIcon"),
+);
+const DiscordIcon = loadableForRemixIcons(
+  () => import("remixicon-react/DiscordLineIcon"),
+);
+const DownArrow = loadableForRemixIcons(
+  () => import("remixicon-react/ArrowDownSFillIcon"),
+);
+const Download = loadableForRemixIcons(
+  () => import("remixicon-react/DownloadCloud2LineIcon"),
+);
+const DuplicateIcon = loadableForRemixIcons(
+  () => import("remixicon-react/FileCopyLineIcon"),
+);
+const PencilFillIcon = loadableForRemixIcons(
+  () => import("remixicon-react/PencilFillIcon"),
+);
+const EditLineIcon = loadableForRemixIcons(
+  () => import("remixicon-react/EditLineIcon"),
+);
+const EditUnderlineIcon = loadableForRemixIcons(
+  () => import("remixicon-react/EditLineIcon"),
+);
+const Emoji = loadableForRemixIcons(
+  () => import("remixicon-react/EmotionLineIcon"),
+);
+const ExpandMore = loadableForRemixIcons(
+  () => import("remixicon-react/ArrowDownSLineIcon"),
+);
+const DownArrowIcon = loadableForRemixIcons(
+  () => import("remixicon-react/ArrowDownSLineIcon"),
+);
+const ExpandLess = loadableForRemixIcons(
+  () => import("remixicon-react/ArrowUpSLineIcon"),
+);
+const EyeOn = loadableForRemixIcons(
+  () => import("remixicon-react/EyeLineIcon"),
+);
+const EyeOff = loadableForRemixIcons(
+  () => import("remixicon-react/EyeOffLineIcon"),
+);
+const FileTransfer = loadableForRemixIcons(
+  () => import("remixicon-react/FileTransferLineIcon"),
+);
+const FileLine = loadableForRemixIcons(
+  () => import("remixicon-react/FileLineIcon"),
+);
+const Filter = loadableForRemixIcons(
+  () => import("remixicon-react/Filter2FillIcon"),
+);
+const ForbidLineIcon = loadableForRemixIcons(
+  () => import("remixicon-react/ForbidLineIcon"),
+);
+const GitMerge = loadableForRemixIcons(
+  () => import("remixicon-react/GitMergeLineIcon"),
+);
+const GitCommit = loadableForRemixIcons(
+  () => import("remixicon-react/GitCommitLineIcon"),
+);
+const GitPullRequest = loadableForRemixIcons(
+  () => import("remixicon-react/GitPullRequestLineIcon"),
+);
+const GlobalLineIcon = loadableForRemixIcons(
+  () => import("remixicon-react/GlobalLineIcon"),
+);
+const GuideIcon = loadableForRemixIcons(
+  () => import("remixicon-react/GuideFillIcon"),
+);
+const QuestionMarkIcon = loadableForRemixIcons(
+  () => import("remixicon-react/QuestionMarkIcon"),
+);
+const LightbulbFlashLine = loadableForRemixIcons(
+  () => import("remixicon-react/LightbulbFlashLineIcon"),
+);
+const LinksLineIcon = loadableForRemixIcons(
+  () => import("remixicon-react/LinksLineIcon"),
+);
+const InfoIcon = loadableForRemixIcons(
+  () => import("remixicon-react/InformationLineIcon"),
+);
+const KeyIcon = loadableForRemixIcons(
+  () => import("remixicon-react/Key2LineIcon"),
+);
+const LeftArrowIcon2 = loadableForRemixIcons(
+  () => import("remixicon-react/ArrowLeftSLineIcon"),
+);
+const Link2 = loadableForRemixIcons(() => import("remixicon-react/LinkIcon"));
+const LeftArrowIcon = loadableForRemixIcons(
+  () => import("remixicon-react/ArrowLeftLineIcon"),
+);
+const NewsPaperLine = loadableForRemixIcons(
+  () => import("remixicon-react/NewspaperLineIcon"),
+);
+const OvalCheck = loadableForRemixIcons(
+  () => import("remixicon-react/CheckboxCircleLineIcon"),
+);
+const OvalCheckFill = loadableForRemixIcons(
+  () => import("remixicon-react/CheckboxCircleFillIcon"),
+);
+const Pin3 = loadableForRemixIcons(
+  () => import("remixicon-react/Pushpin2FillIcon"),
+);
+const PlayCircleLineIcon = loadableForRemixIcons(
+  () => import("remixicon-react/PlayCircleLineIcon"),
+);
+const QueryIcon = loadableForRemixIcons(
+  () => import("remixicon-react/CodeSSlashLineIcon"),
+);
+const SubtractLine = loadableForRemixIcons(
+  () => import("remixicon-react/SubtractLineIcon"),
+);
+const RightArrowIcon = loadableForRemixIcons(
+  () => import("remixicon-react/ArrowRightLineIcon"),
+);
+const RightArrowIcon2 = loadableForRemixIcons(
+  () => import("remixicon-react/ArrowRightSLineIcon"),
+);
+const RocketIcon = loadableForRemixIcons(
+  () => import("remixicon-react/RocketLineIcon"),
+);
+const SearchIcon = loadableForRemixIcons(
+  () => import("remixicon-react/SearchLineIcon"),
+);
+const SortAscIcon = loadableForRemixIcons(
+  () => import("remixicon-react/SortAscIcon"),
+);
+const SortDescIcon = loadableForRemixIcons(
+  () => import("remixicon-react/SortDescIcon"),
+);
+const ShareBoxLineIcon = loadableForRemixIcons(
+  () => import("remixicon-react/ShareBoxLineIcon"),
+);
+const ShareBoxFillIcon = loadableForRemixIcons(
+  () => import("remixicon-react/ShareBoxFillIcon"),
+);
+const ShareForwardIcon = loadableForRemixIcons(
+  () => import("remixicon-react/ShareForwardFillIcon"),
+);
+const Trash = loadableForRemixIcons(
+  () => import("remixicon-react/DeleteBinLineIcon"),
+);
+const UpArrow = loadableForRemixIcons(
+  () => import("remixicon-react/ArrowUpSFillIcon"),
+);
+const WarningIcon = loadableForRemixIcons(
+  () => import("remixicon-react/ErrorWarningFillIcon"),
+);
+const WarningLineIcon = loadableForRemixIcons(
+  () => import("remixicon-react/ErrorWarningLineIcon"),
+);
+const LoginIcon = loadableForRemixIcons(
+  () => import("remixicon-react/LoginBoxLineIcon"),
+);
+const LogoutIcon = loadableForRemixIcons(
+  () => import("remixicon-react/LogoutBoxRLineIcon"),
+);
+const ShareLineIcon = loadableForRemixIcons(
+  () => import("remixicon-react/ShareLineIcon"),
+);
+const LoaderLineIcon = loadableForRemixIcons(
+  () => import("remixicon-react/LoaderLineIcon"),
+);
+const WidgetIcon = loadableForRemixIcons(
+  () => import("remixicon-react/FunctionLineIcon"),
+);
+const RefreshLineIcon = loadableForRemixIcons(
+  () => import("remixicon-react/RefreshLineIcon"),
+);
+const GitBranchLineIcon = loadableForRemixIcons(
+  () => import("remixicon-react/GitBranchLineIcon"),
+);
+const EditBoxLineIcon = loadableForRemixIcons(
+  () => import("remixicon-react/EditBoxLineIcon"),
+);
+const StarLineIcon = loadableForRemixIcons(
+  () => import("remixicon-react/StarLineIcon"),
+);
+const StarFillIcon = loadableForRemixIcons(
+  () => import("remixicon-react/StarFillIcon"),
+);
+const Settings2LineIcon = loadableForRemixIcons(
+  () => import("remixicon-react/Settings2LineIcon"),
+);
+const DownloadIcon = loadableForRemixIcons(
+  () => import("remixicon-react/DownloadLineIcon"),
+);
+const UploadCloud2LineIcon = loadableForRemixIcons(
+  () => import("remixicon-react/UploadCloud2LineIcon"),
+);
+const DownloadLineIcon = loadableForRemixIcons(
+  () => import("remixicon-react/DownloadLineIcon"),
+);
+const UploadLineIcon = loadableForRemixIcons(
+  () => import("remixicon-react/UploadLineIcon"),
+);
+const FileListLineIcon = loadableForRemixIcons(
+  () => import("remixicon-react/FileListLineIcon"),
+);
+const HamburgerIcon = loadableForRemixIcons(
+  () => import("remixicon-react/MenuLineIcon"),
+);
+const MagicLineIcon = loadableForRemixIcons(
+  () => import("remixicon-react/MagicLineIcon"),
+);
+const UserHeartLineIcon = loadableForRemixIcons(
+  () => import("remixicon-react/UserHeartLineIcon"),
+);
+const DvdLineIcon = loadableForRemixIcons(
+  () => import("remixicon-react/DvdLineIcon"),
+);
+const Group2LineIcon = loadableForRemixIcons(
+  () => import("remixicon-react/Group2LineIcon"),
+);
+const CodeViewIcon = loadableForRemixIcons(
+  () => import("remixicon-react/CodeViewIcon"),
+);
+const GroupLineIcon = loadableForRemixIcons(
+  () => import("remixicon-react/GroupLineIcon"),
+);
+const ArrowRightUpLineIcon = loadableForRemixIcons(
+  () => import("remixicon-react/ArrowRightUpLineIcon"),
+);
+const MailCheckLineIcon = loadableForRemixIcons(
+  () => import("remixicon-react/MailCheckLineIcon"),
+);
+const UserFollowLineIcon = loadableForRemixIcons(
+  () => import("remixicon-react/UserFollowLineIcon"),
+);
+const AddBoxLineIcon = loadableForRemixIcons(
+  () => import("remixicon-react/AddBoxLineIcon"),
+);
+const ArrowRightSFillIcon = loadableForRemixIcons(
+  () => import("remixicon-react/ArrowRightSFillIcon"),
+);
+const ArrowDownSFillIcon = loadableForRemixIcons(
+  () => import("remixicon-react/ArrowDownSFillIcon"),
+);
+const MailLineIcon = loadableForRemixIcons(
+  () => import("remixicon-react/MailLineIcon"),
+);
+const LockPasswordLineIcon = loadableForRemixIcons(
+  () => import("remixicon-react/LockPasswordLineIcon"),
+);
+const Timer2LineIcon = loadableForRemixIcons(
+  () => import("remixicon-react/Timer2LineIcon"),
+);
+const MapPin2LineIcon = loadableForRemixIcons(
+  () => import("remixicon-react/MapPin2LineIcon"),
+);
+const User3LineIcon = loadableForRemixIcons(
+  () => import("remixicon-react/User3LineIcon"),
+);
+const User2LineIcon = loadableForRemixIcons(
+  () => import("remixicon-react/User2LineIcon"),
+);
+const Key2LineIcon = loadableForRemixIcons(
+  () => import("remixicon-react/Key2LineIcon"),
+);
+const FileList2LineIcon = loadableForRemixIcons(
+  () => import("remixicon-react/FileList2LineIcon"),
+);
+const Lock2LineIcon = loadableForRemixIcons(
+  () => import("remixicon-react/Lock2LineIcon"),
+);
+const SearchEyeLineIcon = loadableForRemixIcons(
+  () => import("remixicon-react/SearchEyeLineIcon"),
+);
+const AlertLineIcon = loadableForRemixIcons(
+  () => import("remixicon-react/AlertLineIcon"),
+);
+const SettingsLineIcon = loadableForRemixIcons(
+  () => import("remixicon-react/SettingsLineIcon"),
+);
+const LockUnlockLineIcon = loadableForRemixIcons(
+  () => import("remixicon-react/LockUnlockLineIcon"),
+);
+const PantoneLineIcon = loadableForRemixIcons(
+  () => import("remixicon-react/PantoneLineIcon"),
+);
+const QuestionFillIcon = loadableForRemixIcons(
+  () => import("remixicon-react/QuestionFillIcon"),
+);
+const QuestionLineIcon = loadableForRemixIcons(
+  () => import("remixicon-react/QuestionLineIcon"),
+);
+const UserSharedLineIcon = loadableForRemixIcons(
+  () => import("remixicon-react/UserSharedLineIcon"),
+);
+const UserReceived2LineIcon = loadableForRemixIcons(
+  () => import("remixicon-react/UserReceived2LineIcon"),
+);
+const UserAddLineIcon = loadableForRemixIcons(
+  () => import("remixicon-react/UserAddLineIcon"),
+);
+const UserUnfollowLineIcon = loadableForRemixIcons(
+  () => import("remixicon-react/UserUnfollowLineIcon"),
+);
+const DeleteRowIcon = loadableForRemixIcons(
+  () => import("remixicon-react/DeleteRowIcon"),
+);
+const ArrowUpLineIcon = loadableForRemixIcons(
+  () => import("remixicon-react/ArrowUpLineIcon"),
+);
+const MoneyDollarCircleLineIcon = loadableForRemixIcons(
+  () => import("remixicon-react/MoneyDollarCircleLineIcon"),
+);
+const IncreaseV2Icon = loadableForRemixIcons(
+  () => import("remixicon-react/AddLineIcon"),
+);
+const CopyIcon = loadableForRemixIcons(
+  () => import("remixicon-react/FileCopyLineIcon"),
+);
+const QuestionIcon = loadableForRemixIcons(
+  () => import("remixicon-react/QuestionLineIcon"),
+);
+const SettingsIcon = loadableForRemixIcons(
+  () => import("remixicon-react/Settings5LineIcon"),
+);
+const EyeIcon = loadableForRemixIcons(
+  () => import("remixicon-react/EyeLineIcon"),
+);
+const EyeOffIcon = loadableForRemixIcons(
+  () => import("remixicon-react/EyeOffLineIcon"),
+);
+const CloseIcon = loadableForRemixIcons(
+  () => import("remixicon-react/CloseLineIcon"),
+);
+const SubtractIcon = loadableForRemixIcons(
+  () => import("remixicon-react/SubtractFillIcon"),
+);
+const BookLineIcon = loadableForSvg(
+  () => import("../__assets__/icons/ads/book-open-line.svg"),
+);
+const BugIcon = loadableForSvg(() => import("../__assets__/icons/ads/bug.svg"));
+const CancelIcon = loadableForSvg(
+  () => import("../__assets__/icons/ads/cancel.svg"),
+);
+const CrossIcon = loadableForSvg(
+  () => import("../__assets__/icons/ads/cross.svg"),
+);
+const Fork2Icon = loadableForSvg(
+  () => import("../__assets__/icons/ads/fork-2.svg"),
+);
+const OpenIcon = loadableForSvg(
+  () => import("../__assets__/icons/ads/open.svg"),
+);
+const UserIcon = loadableForSvg(
+  () => import("../__assets__/icons/ads/user.svg"),
+);
+const GeneralIcon = loadableForSvg(
+  () => import("../__assets__/icons/ads/general.svg"),
+);
+const BillingIcon = loadableForSvg(
+  () => import("../__assets__/icons/ads/billing.svg"),
+);
+const ErrorIcon = loadableForSvg(
+  () => import("../__assets__/icons/ads/error.svg"),
+);
+const ShineIcon = loadableForSvg(
+  () => import("../__assets__/icons/ads/shine.svg"),
+);
+const SuccessIcon = loadableForSvg(
+  () => import("../__assets__/icons/ads/success.svg"),
+);
+const WarningTriangleIcon = loadableForSvg(
+  () => import("../__assets__/icons/ads/warning-triangle.svg"),
+);
+const ShareIcon2 = loadableForSvg(
+  () => import("../__assets__/icons/ads/share-2.svg"),
+);
+const InviteUserIcon = loadableForSvg(
+  () => import("../__assets__/icons/ads/invite-users.svg"),
+);
+const ManageIcon = loadableForSvg(
+  () => import("../__assets__/icons/ads/manage.svg"),
+);
+const ArrowLeft = loadableForSvg(
+  () => import("../__assets__/icons/ads/arrow-left.svg"),
+);
+const ChevronLeft = loadableForSvg(
+  () => import("../__assets__/icons/ads/chevron_left.svg"),
+);
+const LinkIcon = loadableForSvg(
+  () => import("../__assets__/icons/ads/link.svg"),
+);
+const NoResponseIcon = loadableForSvg(
+  () => import("../__assets__/icons/ads/no-response.svg"),
+);
+const LightningIcon = loadableForSvg(
+  () => import("../__assets__/icons/ads/lightning.svg"),
+);
+const TrendingFlat = loadableForSvg(
+  () => import("../__assets__/icons/ads/trending-flat.svg"),
+);
+const PlayIcon = loadableForSvg(
+  () => import("../__assets__/icons/ads/play.svg"),
+);
+const DesktopIcon = loadableForSvg(
+  () => import("../__assets__/icons/ads/desktop.svg"),
+);
+const WandIcon = loadableForSvg(
+  () => import("../__assets__/icons/ads/wand.svg"),
+);
+const MobileIcon = loadableForSvg(
+  () => import("../__assets__/icons/ads/mobile.svg"),
+);
+const TabletIcon = loadableForSvg(
+  () => import("../__assets__/icons/ads/tablet.svg"),
+);
+const TabletLandscapeIcon = loadableForSvg(
+  () => import("../__assets__/icons/ads/tablet-landscape.svg"),
+);
+const FluidIcon = loadableForSvg(
+  () => import("../__assets__/icons/ads/fluid.svg"),
+);
+const CardContextMenu = loadableForSvg(
+  () => import("../__assets__/icons/ads/card-context-menu.svg"),
+);
+const SendButton = loadableForSvg(
+  () => import("../__assets__/icons/comments/send-button.svg"),
+);
+const Pin = loadableForSvg(
+  () => import("../__assets__/icons/comments/pin.svg"),
+);
+const TrashOutline = loadableForSvg(
+  () => import("../__assets__/icons/form/trash.svg"),
+);
+const ReadPin = loadableForSvg(
+  () => import("../__assets__/icons/comments/read-pin.svg"),
+);
+const UnreadPin = loadableForSvg(
+  () => import("../__assets__/icons/comments/unread-pin.svg"),
+);
+const Chat = loadableForSvg(
+  () => import("../__assets__/icons/comments/chat.svg"),
+);
+const Unpin = loadableForSvg(
+  () => import("../__assets__/icons/comments/unpinIcon.svg"),
+);
+const Reaction = loadableForSvg(
+  () => import("../__assets__/icons/comments/reaction.svg"),
+);
+const Reaction2 = loadableForSvg(
+  () => import("../__assets__/icons/comments/reaction-2.svg"),
+);
+const Upload = loadableForSvg(
+  () => import("../__assets__/icons/ads/upload.svg"),
+);
+const ArrowForwardIcon = loadableForSvg(
+  () => import("../__assets__/icons/control/arrow_forward.svg"),
+);
+const DoubleArrowRightIcon = loadableForSvg(
+  () => import("../__assets__/icons/ads/double-arrow-right.svg"),
+);
+const CapSolidIcon = loadableForSvg(
+  () => import("../__assets__/icons/control/cap_solid.svg"),
+);
+const CapDotIcon = loadableForSvg(
+  () => import("../__assets__/icons/control/cap_dot.svg"),
+);
+const LineDottedIcon = loadableForSvg(
+  () => import("../__assets__/icons/control/line_dotted.svg"),
+);
+const LineDashedIcon = loadableForSvg(
+  () => import("../__assets__/icons/control/line_dashed.svg"),
+);
+const TableIcon = loadableForSvg(
+  () => import("../__assets__/icons/ads/tables.svg"),
+);
+const ColumnIcon = loadableForSvg(
+  () => import("../__assets__/icons/ads/column.svg"),
+);
+const GearIcon = loadableForSvg(
+  () => import("../__assets__/icons/ads/gear.svg"),
+);
+const UserV2Icon = loadableForSvg(
+  () => import("../__assets__/icons/ads/user-v2.svg"),
+);
+const SupportIcon = loadableForSvg(
+  () => import("../__assets__/icons/ads/support.svg"),
+);
+const Snippet = loadableForSvg(
+  () => import("../__assets__/icons/ads/snippet.svg"),
+);
+const WorkspaceIcon = loadableForSvg(
+  () => import("../__assets__/icons/ads/workspaceIcon.svg"),
+);
+const SettingIcon = loadableForSvg(
+  () => import("../__assets__/icons/control/settings.svg"),
+);
+const DropdownIcon = loadableForSvg(
+  () => import("../__assets__/icons/ads/dropdown.svg"),
+);
+const ChatIcon = loadableForSvg(
+  () => import("../__assets__/icons/ads/app-icons/chat.svg"),
+);
+const JsIcon = loadableForSvg(() => import("../__assets__/icons/ads/js.svg"));
+const ExecuteIcon = loadableForSvg(
+  () => import("../__assets__/icons/ads/execute.svg"),
+);
+const PackageIcon = loadableForSvg(
+  () => import("../__assets__/icons/ads/package.svg"),
+);
+const DeleteIcon = loadableForSvg(
+  () => import("../__assets__/icons/control/delete.svg"),
+);
+const MoveIcon = loadableForSvg(
+  () => import("../__assets__/icons/control/move.svg"),
+);
+const EditIcon = loadableForSvg(
+  () => import("../__assets__/icons/control/edit.svg"),
+);
+const ViewIcon = loadableForSvg(
+  () => import("../__assets__/icons/control/view.svg"),
+);
+const MoreVerticalIcon = loadableForSvg(
+  () => import("../__assets__/icons/control/more-vertical.svg"),
+);
+const OverflowMenuIcon = loadableForSvg(
+  () => import("../__assets__/icons/menu/overflow-menu.svg"),
+);
+const JsToggleIcon = loadableForSvg(
+  () => import("../__assets__/icons/control/js-toggle.svg"),
+);
+const IncreaseIcon = loadableForSvg(
+  () => import("../__assets__/icons/control/increase.svg"),
+);
+const DecreaseIcon = loadableForSvg(
+  () => import("../__assets__/icons/control/decrease.svg"),
+);
+const DraggableIcon = loadableForSvg(
+  () => import("../__assets__/icons/control/draggable.svg"),
+);
+const AddCircleIcon = loadableForSvg(
+  () => import("../__assets__/icons/control/add-circle.svg"),
+);
+const HelpIcon = loadableForSvg(
+  () => import("../__assets__/icons/control/help.svg"),
+);
+const CollapseIcon = loadableForSvg(
+  () => import("../__assets__/icons/control/collapse.svg"),
+);
+const PickMyLocationSelectedIcon = loadableForSvg(
+  () => import("../__assets__/icons/control/pick-location-selected.svg"),
+);
+const RemoveIcon = loadableForSvg(
+  () => import("../__assets__/icons/control/remove.svg"),
+);
+const DragIcon = loadableForSvg(
+  () => import("../__assets__/icons/control/drag.svg"),
+);
+const SortIcon = loadableForSvg(
+  () => import("../__assets__/icons/control/sort-icon.svg"),
+);
+const EditWhiteIcon = loadableForSvg(
+  () => import("../__assets__/icons/control/edit-white.svg"),
+);
+const LaunchIcon = loadableForSvg(
+  () => import("../__assets__/icons/control/launch.svg"),
+);
+const BackIcon = loadableForSvg(
+  () => import("../__assets__/icons/control/back.svg"),
+);
+const DeleteColumnIcon = loadableForSvg(
+  () => import("../__assets__/icons/control/delete-column.svg"),
+);
+const BoldFontIcon = loadableForSvg(
+  () => import("../__assets__/icons/control/bold.svg"),
+);
+const UnderlineIcon = loadableForSvg(
+  () => import("../__assets__/icons/control/underline.svg"),
+);
+const ItalicsFontIcon = loadableForSvg(
+  () => import("../__assets__/icons/control/italics.svg"),
+);
+const LeftAlignIcon = loadableForSvg(
+  () => import("../__assets__/icons/control/left-align.svg"),
+);
+const CenterAlignIcon = loadableForSvg(
+  () => import("../__assets__/icons/control/center-align.svg"),
+);
+const RightAlignIcon = loadableForSvg(
+  () => import("../__assets__/icons/control/right-align.svg"),
+);
+const VerticalAlignRight = loadableForSvg(
+  () => import("../__assets__/icons/control/align_right.svg"),
+);
+const VerticalAlignLeft = loadableForSvg(
+  () => import("../__assets__/icons/control/align_left.svg"),
+);
+const VerticalAlignBottom = loadableForSvg(
+  () => import("../__assets__/icons/control/vertical_align_bottom.svg"),
+);
+const VerticalAlignCenter = loadableForSvg(
+  () => import("../__assets__/icons/control/vertical_align_center.svg"),
+);
+const VerticalAlignTop = loadableForSvg(
+  () => import("../__assets__/icons/control/vertical_align_top.svg"),
+);
+const Copy2Icon = loadableForSvg(
+  () => import("../__assets__/icons/control/copy2.svg"),
+);
+const CutIcon = loadableForSvg(
+  () => import("../__assets__/icons/control/cut.svg"),
+);
+const GroupIcon = loadableForSvg(
+  () => import("../__assets__/icons/control/group.svg"),
+);
+const HeadingOneIcon = loadableForSvg(
+  () => import("../__assets__/icons/control/heading_1.svg"),
+);
+const HeadingTwoIcon = loadableForSvg(
+  () => import("../__assets__/icons/control/heading_2.svg"),
+);
+const HeadingThreeIcon = loadableForSvg(
+  () => import("../__assets__/icons/control/heading_3.svg"),
+);
+const ParagraphIcon = loadableForSvg(
+  () => import("../__assets__/icons/control/paragraph.svg"),
+);
+const ParagraphTwoIcon = loadableForSvg(
+  () => import("../__assets__/icons/control/paragraph_2.svg"),
+);
+const BulletsIcon = loadableForSvg(
+  () => import("../__assets__/icons/control/bullets.svg"),
+);
+const DividerCapRightIcon = loadableForSvg(
+  () => import("../__assets__/icons/control/divider_cap_right.svg"),
+);
+const DividerCapLeftIcon = loadableForSvg(
+  () => import("../__assets__/icons/control/divider_cap_left.svg"),
+);
+const DividerCapAllIcon = loadableForSvg(
+  () => import("../__assets__/icons/control/divider_cap_all.svg"),
+);
+const AlignLeftIcon = loadableForSvg(
+  () => import("../__assets__/icons/control/align_left.svg"),
+);
+const AlignRightIcon = loadableForSvg(
+  () => import("../__assets__/icons/control/align_right.svg"),
+);
+const BorderRadiusSharpIcon = loadableForSvg(
+  () => import("../__assets__/icons/control/border-radius-sharp.svg"),
+);
+const BorderRadiusRoundedIcon = loadableForSvg(
+  () => import("../__assets__/icons/control/border-radius-rounded.svg"),
+);
+const BorderRadiusCircleIcon = loadableForSvg(
+  () => import("../__assets__/icons/control/border-radius-circle.svg"),
+);
+const BoxShadowNoneIcon = loadableForSvg(
+  () => import("../__assets__/icons/control/box-shadow-none.svg"),
+);
+const BoxShadowVariant1Icon = loadableForSvg(
+  () => import("../__assets__/icons/control/box-shadow-variant1.svg"),
+);
+const BoxShadowVariant2Icon = loadableForSvg(
+  () => import("../__assets__/icons/control/box-shadow-variant2.svg"),
+);
+const BoxShadowVariant3Icon = loadableForSvg(
+  () => import("../__assets__/icons/control/box-shadow-variant3.svg"),
+);
+const BoxShadowVariant4Icon = loadableForSvg(
+  () => import("../__assets__/icons/control/box-shadow-variant4.svg"),
+);
+const BoxShadowVariant5Icon = loadableForSvg(
+  () => import("../__assets__/icons/control/box-shadow-variant5.svg"),
+);
+const JsToggleV2 = loadableForSvg(
+  () => import("../__assets__/icons/ads/js-toggle-v2.svg"),
+);
 
 function PlayIconPNGWrapper() {
   return (
@@ -537,6 +1021,8 @@ export function IconProvider(props: {
 
   const Icon = ICON_LOOKUP[iconName as keyof typeof ICON_LOOKUP]
     ? ICON_LOOKUP[iconName as keyof typeof ICON_LOOKUP]
-    : require(`remixicon-react/${pascalCaseIconName}Icon`);
+    : loadableForRemixIcons(
+        () => import(`remixicon-react/${pascalCaseIconName}Icon`),
+      );
   return Icon && <Icon color={color} size={size} />;
 }

--- a/packages/design-system/src/Icon/Icon.provider.tsx
+++ b/packages/design-system/src/Icon/Icon.provider.tsx
@@ -1,731 +1,681 @@
 import React from "react";
 import PlayIconPNG from "../__assets__/icons/control/play-icon.png";
-import { loadableForRemixIcons, loadableForSvg } from "./loadables";
+import { importRemixIcon, importSvg } from "./loadables";
 
-const AddMoreIcon = loadableForRemixIcons(
+const AddMoreIcon = importRemixIcon(
   () => import("remixicon-react/AddCircleLineIcon"),
 );
-const AddMoreFillIcon = loadableForRemixIcons(
+const AddMoreFillIcon = importRemixIcon(
   () => import("remixicon-react/AddCircleFillIcon"),
 );
-const ArrowLeftRightIcon = loadableForRemixIcons(
+const ArrowLeftRightIcon = importRemixIcon(
   () => import("remixicon-react/ArrowLeftRightLineIcon"),
 );
-const ArrowDownLineIcon = loadableForRemixIcons(
+const ArrowDownLineIcon = importRemixIcon(
   () => import("remixicon-react/ArrowDownLineIcon"),
 );
-const BookIcon = loadableForRemixIcons(
+const BookIcon = importRemixIcon(
   () => import("remixicon-react/BookOpenLineIcon"),
 );
-const BugLineIcon = loadableForRemixIcons(
+const BugLineIcon = importRemixIcon(
   () => import("remixicon-react/BugLineIcon"),
 );
-const ChevronRight = loadableForRemixIcons(
+const ChevronRight = importRemixIcon(
   () => import("remixicon-react/ArrowRightSFillIcon"),
 );
-const CheckLineIcon = loadableForRemixIcons(
+const CheckLineIcon = importRemixIcon(
   () => import("remixicon-react/CheckLineIcon"),
 );
-const CloseLineIcon = loadableForRemixIcons(
+const CloseLineIcon = importRemixIcon(
   () => import("remixicon-react/CloseLineIcon"),
 );
-const CloseCircleIcon = loadableForRemixIcons(
+const CloseCircleIcon = importRemixIcon(
   () => import("remixicon-react/CloseCircleFillIcon"),
 );
-const CloudOfflineIcon = loadableForRemixIcons(
+const CloudOfflineIcon = importRemixIcon(
   () => import("remixicon-react/CloudOffLineIcon"),
 );
-const CommentContextMenu = loadableForRemixIcons(
+const CommentContextMenu = importRemixIcon(
   () => import("remixicon-react/More2FillIcon"),
 );
-const More2FillIcon = loadableForRemixIcons(
+const More2FillIcon = importRemixIcon(
   () => import("remixicon-react/More2FillIcon"),
 );
-const CompassesLine = loadableForRemixIcons(
+const CompassesLine = importRemixIcon(
   () => import("remixicon-react/CompassesLineIcon"),
 );
-const ContextMenuIcon = loadableForRemixIcons(
+const ContextMenuIcon = importRemixIcon(
   () => import("remixicon-react/MoreFillIcon"),
 );
-const CreateNewIcon = loadableForRemixIcons(
+const CreateNewIcon = importRemixIcon(
   () => import("remixicon-react/AddLineIcon"),
 );
-const Database2Line = loadableForRemixIcons(
+const Database2Line = importRemixIcon(
   () => import("remixicon-react/Database2LineIcon"),
 );
-const DatasourceIcon = loadableForRemixIcons(
+const DatasourceIcon = importRemixIcon(
   () => import("remixicon-react/CloudFillIcon"),
 );
-const DeleteBin7 = loadableForRemixIcons(
+const DeleteBin7 = importRemixIcon(
   () => import("remixicon-react/DeleteBin7LineIcon"),
 );
-const DiscordIcon = loadableForRemixIcons(
+const DiscordIcon = importRemixIcon(
   () => import("remixicon-react/DiscordLineIcon"),
 );
-const DownArrow = loadableForRemixIcons(
+const DownArrow = importRemixIcon(
   () => import("remixicon-react/ArrowDownSFillIcon"),
 );
-const Download = loadableForRemixIcons(
+const Download = importRemixIcon(
   () => import("remixicon-react/DownloadCloud2LineIcon"),
 );
-const DuplicateIcon = loadableForRemixIcons(
+const DuplicateIcon = importRemixIcon(
   () => import("remixicon-react/FileCopyLineIcon"),
 );
-const PencilFillIcon = loadableForRemixIcons(
+const PencilFillIcon = importRemixIcon(
   () => import("remixicon-react/PencilFillIcon"),
 );
-const EditLineIcon = loadableForRemixIcons(
+const EditLineIcon = importRemixIcon(
   () => import("remixicon-react/EditLineIcon"),
 );
-const EditUnderlineIcon = loadableForRemixIcons(
+const EditUnderlineIcon = importRemixIcon(
   () => import("remixicon-react/EditLineIcon"),
 );
-const Emoji = loadableForRemixIcons(
-  () => import("remixicon-react/EmotionLineIcon"),
-);
-const ExpandMore = loadableForRemixIcons(
+const Emoji = importRemixIcon(() => import("remixicon-react/EmotionLineIcon"));
+const ExpandMore = importRemixIcon(
   () => import("remixicon-react/ArrowDownSLineIcon"),
 );
-const DownArrowIcon = loadableForRemixIcons(
+const DownArrowIcon = importRemixIcon(
   () => import("remixicon-react/ArrowDownSLineIcon"),
 );
-const ExpandLess = loadableForRemixIcons(
+const ExpandLess = importRemixIcon(
   () => import("remixicon-react/ArrowUpSLineIcon"),
 );
-const EyeOn = loadableForRemixIcons(
-  () => import("remixicon-react/EyeLineIcon"),
-);
-const EyeOff = loadableForRemixIcons(
-  () => import("remixicon-react/EyeOffLineIcon"),
-);
-const FileTransfer = loadableForRemixIcons(
+const EyeOn = importRemixIcon(() => import("remixicon-react/EyeLineIcon"));
+const EyeOff = importRemixIcon(() => import("remixicon-react/EyeOffLineIcon"));
+const FileTransfer = importRemixIcon(
   () => import("remixicon-react/FileTransferLineIcon"),
 );
-const FileLine = loadableForRemixIcons(
-  () => import("remixicon-react/FileLineIcon"),
-);
-const Filter = loadableForRemixIcons(
-  () => import("remixicon-react/Filter2FillIcon"),
-);
-const ForbidLineIcon = loadableForRemixIcons(
+const FileLine = importRemixIcon(() => import("remixicon-react/FileLineIcon"));
+const Filter = importRemixIcon(() => import("remixicon-react/Filter2FillIcon"));
+const ForbidLineIcon = importRemixIcon(
   () => import("remixicon-react/ForbidLineIcon"),
 );
-const GitMerge = loadableForRemixIcons(
+const GitMerge = importRemixIcon(
   () => import("remixicon-react/GitMergeLineIcon"),
 );
-const GitCommit = loadableForRemixIcons(
+const GitCommit = importRemixIcon(
   () => import("remixicon-react/GitCommitLineIcon"),
 );
-const GitPullRequest = loadableForRemixIcons(
+const GitPullRequest = importRemixIcon(
   () => import("remixicon-react/GitPullRequestLineIcon"),
 );
-const GlobalLineIcon = loadableForRemixIcons(
+const GlobalLineIcon = importRemixIcon(
   () => import("remixicon-react/GlobalLineIcon"),
 );
-const GuideIcon = loadableForRemixIcons(
+const GuideIcon = importRemixIcon(
   () => import("remixicon-react/GuideFillIcon"),
 );
-const QuestionMarkIcon = loadableForRemixIcons(
+const QuestionMarkIcon = importRemixIcon(
   () => import("remixicon-react/QuestionMarkIcon"),
 );
-const LightbulbFlashLine = loadableForRemixIcons(
+const LightbulbFlashLine = importRemixIcon(
   () => import("remixicon-react/LightbulbFlashLineIcon"),
 );
-const LinksLineIcon = loadableForRemixIcons(
+const LinksLineIcon = importRemixIcon(
   () => import("remixicon-react/LinksLineIcon"),
 );
-const InfoIcon = loadableForRemixIcons(
+const InfoIcon = importRemixIcon(
   () => import("remixicon-react/InformationLineIcon"),
 );
-const KeyIcon = loadableForRemixIcons(
-  () => import("remixicon-react/Key2LineIcon"),
-);
-const LeftArrowIcon2 = loadableForRemixIcons(
+const KeyIcon = importRemixIcon(() => import("remixicon-react/Key2LineIcon"));
+const LeftArrowIcon2 = importRemixIcon(
   () => import("remixicon-react/ArrowLeftSLineIcon"),
 );
-const Link2 = loadableForRemixIcons(() => import("remixicon-react/LinkIcon"));
-const LeftArrowIcon = loadableForRemixIcons(
+const Link2 = importRemixIcon(() => import("remixicon-react/LinkIcon"));
+const LeftArrowIcon = importRemixIcon(
   () => import("remixicon-react/ArrowLeftLineIcon"),
 );
-const NewsPaperLine = loadableForRemixIcons(
+const NewsPaperLine = importRemixIcon(
   () => import("remixicon-react/NewspaperLineIcon"),
 );
-const OvalCheck = loadableForRemixIcons(
+const OvalCheck = importRemixIcon(
   () => import("remixicon-react/CheckboxCircleLineIcon"),
 );
-const OvalCheckFill = loadableForRemixIcons(
+const OvalCheckFill = importRemixIcon(
   () => import("remixicon-react/CheckboxCircleFillIcon"),
 );
-const Pin3 = loadableForRemixIcons(
-  () => import("remixicon-react/Pushpin2FillIcon"),
-);
-const PlayCircleLineIcon = loadableForRemixIcons(
+const Pin3 = importRemixIcon(() => import("remixicon-react/Pushpin2FillIcon"));
+const PlayCircleLineIcon = importRemixIcon(
   () => import("remixicon-react/PlayCircleLineIcon"),
 );
-const QueryIcon = loadableForRemixIcons(
+const QueryIcon = importRemixIcon(
   () => import("remixicon-react/CodeSSlashLineIcon"),
 );
-const SubtractLine = loadableForRemixIcons(
+const SubtractLine = importRemixIcon(
   () => import("remixicon-react/SubtractLineIcon"),
 );
-const RightArrowIcon = loadableForRemixIcons(
+const RightArrowIcon = importRemixIcon(
   () => import("remixicon-react/ArrowRightLineIcon"),
 );
-const RightArrowIcon2 = loadableForRemixIcons(
+const RightArrowIcon2 = importRemixIcon(
   () => import("remixicon-react/ArrowRightSLineIcon"),
 );
-const RocketIcon = loadableForRemixIcons(
+const RocketIcon = importRemixIcon(
   () => import("remixicon-react/RocketLineIcon"),
 );
-const SearchIcon = loadableForRemixIcons(
+const SearchIcon = importRemixIcon(
   () => import("remixicon-react/SearchLineIcon"),
 );
-const SortAscIcon = loadableForRemixIcons(
+const SortAscIcon = importRemixIcon(
   () => import("remixicon-react/SortAscIcon"),
 );
-const SortDescIcon = loadableForRemixIcons(
+const SortDescIcon = importRemixIcon(
   () => import("remixicon-react/SortDescIcon"),
 );
-const ShareBoxLineIcon = loadableForRemixIcons(
+const ShareBoxLineIcon = importRemixIcon(
   () => import("remixicon-react/ShareBoxLineIcon"),
 );
-const ShareBoxFillIcon = loadableForRemixIcons(
+const ShareBoxFillIcon = importRemixIcon(
   () => import("remixicon-react/ShareBoxFillIcon"),
 );
-const ShareForwardIcon = loadableForRemixIcons(
+const ShareForwardIcon = importRemixIcon(
   () => import("remixicon-react/ShareForwardFillIcon"),
 );
-const Trash = loadableForRemixIcons(
+const Trash = importRemixIcon(
   () => import("remixicon-react/DeleteBinLineIcon"),
 );
-const UpArrow = loadableForRemixIcons(
+const UpArrow = importRemixIcon(
   () => import("remixicon-react/ArrowUpSFillIcon"),
 );
-const WarningIcon = loadableForRemixIcons(
+const WarningIcon = importRemixIcon(
   () => import("remixicon-react/ErrorWarningFillIcon"),
 );
-const WarningLineIcon = loadableForRemixIcons(
+const WarningLineIcon = importRemixIcon(
   () => import("remixicon-react/ErrorWarningLineIcon"),
 );
-const LoginIcon = loadableForRemixIcons(
+const LoginIcon = importRemixIcon(
   () => import("remixicon-react/LoginBoxLineIcon"),
 );
-const LogoutIcon = loadableForRemixIcons(
+const LogoutIcon = importRemixIcon(
   () => import("remixicon-react/LogoutBoxRLineIcon"),
 );
-const ShareLineIcon = loadableForRemixIcons(
+const ShareLineIcon = importRemixIcon(
   () => import("remixicon-react/ShareLineIcon"),
 );
-const LoaderLineIcon = loadableForRemixIcons(
+const LoaderLineIcon = importRemixIcon(
   () => import("remixicon-react/LoaderLineIcon"),
 );
-const WidgetIcon = loadableForRemixIcons(
+const WidgetIcon = importRemixIcon(
   () => import("remixicon-react/FunctionLineIcon"),
 );
-const RefreshLineIcon = loadableForRemixIcons(
+const RefreshLineIcon = importRemixIcon(
   () => import("remixicon-react/RefreshLineIcon"),
 );
-const GitBranchLineIcon = loadableForRemixIcons(
+const GitBranchLineIcon = importRemixIcon(
   () => import("remixicon-react/GitBranchLineIcon"),
 );
-const EditBoxLineIcon = loadableForRemixIcons(
+const EditBoxLineIcon = importRemixIcon(
   () => import("remixicon-react/EditBoxLineIcon"),
 );
-const StarLineIcon = loadableForRemixIcons(
+const StarLineIcon = importRemixIcon(
   () => import("remixicon-react/StarLineIcon"),
 );
-const StarFillIcon = loadableForRemixIcons(
+const StarFillIcon = importRemixIcon(
   () => import("remixicon-react/StarFillIcon"),
 );
-const Settings2LineIcon = loadableForRemixIcons(
+const Settings2LineIcon = importRemixIcon(
   () => import("remixicon-react/Settings2LineIcon"),
 );
-const DownloadIcon = loadableForRemixIcons(
+const DownloadIcon = importRemixIcon(
   () => import("remixicon-react/DownloadLineIcon"),
 );
-const UploadCloud2LineIcon = loadableForRemixIcons(
+const UploadCloud2LineIcon = importRemixIcon(
   () => import("remixicon-react/UploadCloud2LineIcon"),
 );
-const DownloadLineIcon = loadableForRemixIcons(
+const DownloadLineIcon = importRemixIcon(
   () => import("remixicon-react/DownloadLineIcon"),
 );
-const UploadLineIcon = loadableForRemixIcons(
+const UploadLineIcon = importRemixIcon(
   () => import("remixicon-react/UploadLineIcon"),
 );
-const FileListLineIcon = loadableForRemixIcons(
+const FileListLineIcon = importRemixIcon(
   () => import("remixicon-react/FileListLineIcon"),
 );
-const HamburgerIcon = loadableForRemixIcons(
+const HamburgerIcon = importRemixIcon(
   () => import("remixicon-react/MenuLineIcon"),
 );
-const MagicLineIcon = loadableForRemixIcons(
+const MagicLineIcon = importRemixIcon(
   () => import("remixicon-react/MagicLineIcon"),
 );
-const UserHeartLineIcon = loadableForRemixIcons(
+const UserHeartLineIcon = importRemixIcon(
   () => import("remixicon-react/UserHeartLineIcon"),
 );
-const DvdLineIcon = loadableForRemixIcons(
+const DvdLineIcon = importRemixIcon(
   () => import("remixicon-react/DvdLineIcon"),
 );
-const Group2LineIcon = loadableForRemixIcons(
+const Group2LineIcon = importRemixIcon(
   () => import("remixicon-react/Group2LineIcon"),
 );
-const CodeViewIcon = loadableForRemixIcons(
+const CodeViewIcon = importRemixIcon(
   () => import("remixicon-react/CodeViewIcon"),
 );
-const GroupLineIcon = loadableForRemixIcons(
+const GroupLineIcon = importRemixIcon(
   () => import("remixicon-react/GroupLineIcon"),
 );
-const ArrowRightUpLineIcon = loadableForRemixIcons(
+const ArrowRightUpLineIcon = importRemixIcon(
   () => import("remixicon-react/ArrowRightUpLineIcon"),
 );
-const MailCheckLineIcon = loadableForRemixIcons(
+const MailCheckLineIcon = importRemixIcon(
   () => import("remixicon-react/MailCheckLineIcon"),
 );
-const UserFollowLineIcon = loadableForRemixIcons(
+const UserFollowLineIcon = importRemixIcon(
   () => import("remixicon-react/UserFollowLineIcon"),
 );
-const AddBoxLineIcon = loadableForRemixIcons(
+const AddBoxLineIcon = importRemixIcon(
   () => import("remixicon-react/AddBoxLineIcon"),
 );
-const ArrowRightSFillIcon = loadableForRemixIcons(
+const ArrowRightSFillIcon = importRemixIcon(
   () => import("remixicon-react/ArrowRightSFillIcon"),
 );
-const ArrowDownSFillIcon = loadableForRemixIcons(
+const ArrowDownSFillIcon = importRemixIcon(
   () => import("remixicon-react/ArrowDownSFillIcon"),
 );
-const MailLineIcon = loadableForRemixIcons(
+const MailLineIcon = importRemixIcon(
   () => import("remixicon-react/MailLineIcon"),
 );
-const LockPasswordLineIcon = loadableForRemixIcons(
+const LockPasswordLineIcon = importRemixIcon(
   () => import("remixicon-react/LockPasswordLineIcon"),
 );
-const Timer2LineIcon = loadableForRemixIcons(
+const Timer2LineIcon = importRemixIcon(
   () => import("remixicon-react/Timer2LineIcon"),
 );
-const MapPin2LineIcon = loadableForRemixIcons(
+const MapPin2LineIcon = importRemixIcon(
   () => import("remixicon-react/MapPin2LineIcon"),
 );
-const User3LineIcon = loadableForRemixIcons(
+const User3LineIcon = importRemixIcon(
   () => import("remixicon-react/User3LineIcon"),
 );
-const User2LineIcon = loadableForRemixIcons(
+const User2LineIcon = importRemixIcon(
   () => import("remixicon-react/User2LineIcon"),
 );
-const Key2LineIcon = loadableForRemixIcons(
+const Key2LineIcon = importRemixIcon(
   () => import("remixicon-react/Key2LineIcon"),
 );
-const FileList2LineIcon = loadableForRemixIcons(
+const FileList2LineIcon = importRemixIcon(
   () => import("remixicon-react/FileList2LineIcon"),
 );
-const Lock2LineIcon = loadableForRemixIcons(
+const Lock2LineIcon = importRemixIcon(
   () => import("remixicon-react/Lock2LineIcon"),
 );
-const SearchEyeLineIcon = loadableForRemixIcons(
+const SearchEyeLineIcon = importRemixIcon(
   () => import("remixicon-react/SearchEyeLineIcon"),
 );
-const AlertLineIcon = loadableForRemixIcons(
+const AlertLineIcon = importRemixIcon(
   () => import("remixicon-react/AlertLineIcon"),
 );
-const SettingsLineIcon = loadableForRemixIcons(
+const SettingsLineIcon = importRemixIcon(
   () => import("remixicon-react/SettingsLineIcon"),
 );
-const LockUnlockLineIcon = loadableForRemixIcons(
+const LockUnlockLineIcon = importRemixIcon(
   () => import("remixicon-react/LockUnlockLineIcon"),
 );
-const PantoneLineIcon = loadableForRemixIcons(
+const PantoneLineIcon = importRemixIcon(
   () => import("remixicon-react/PantoneLineIcon"),
 );
-const QuestionFillIcon = loadableForRemixIcons(
+const QuestionFillIcon = importRemixIcon(
   () => import("remixicon-react/QuestionFillIcon"),
 );
-const QuestionLineIcon = loadableForRemixIcons(
+const QuestionLineIcon = importRemixIcon(
   () => import("remixicon-react/QuestionLineIcon"),
 );
-const UserSharedLineIcon = loadableForRemixIcons(
+const UserSharedLineIcon = importRemixIcon(
   () => import("remixicon-react/UserSharedLineIcon"),
 );
-const UserReceived2LineIcon = loadableForRemixIcons(
+const UserReceived2LineIcon = importRemixIcon(
   () => import("remixicon-react/UserReceived2LineIcon"),
 );
-const UserAddLineIcon = loadableForRemixIcons(
+const UserAddLineIcon = importRemixIcon(
   () => import("remixicon-react/UserAddLineIcon"),
 );
-const UserUnfollowLineIcon = loadableForRemixIcons(
+const UserUnfollowLineIcon = importRemixIcon(
   () => import("remixicon-react/UserUnfollowLineIcon"),
 );
-const DeleteRowIcon = loadableForRemixIcons(
+const DeleteRowIcon = importRemixIcon(
   () => import("remixicon-react/DeleteRowIcon"),
 );
-const ArrowUpLineIcon = loadableForRemixIcons(
+const ArrowUpLineIcon = importRemixIcon(
   () => import("remixicon-react/ArrowUpLineIcon"),
 );
-const MoneyDollarCircleLineIcon = loadableForRemixIcons(
+const MoneyDollarCircleLineIcon = importRemixIcon(
   () => import("remixicon-react/MoneyDollarCircleLineIcon"),
 );
-const IncreaseV2Icon = loadableForRemixIcons(
+const IncreaseV2Icon = importRemixIcon(
   () => import("remixicon-react/AddLineIcon"),
 );
-const CopyIcon = loadableForRemixIcons(
+const CopyIcon = importRemixIcon(
   () => import("remixicon-react/FileCopyLineIcon"),
 );
-const QuestionIcon = loadableForRemixIcons(
+const QuestionIcon = importRemixIcon(
   () => import("remixicon-react/QuestionLineIcon"),
 );
-const SettingsIcon = loadableForRemixIcons(
+const SettingsIcon = importRemixIcon(
   () => import("remixicon-react/Settings5LineIcon"),
 );
-const EyeIcon = loadableForRemixIcons(
-  () => import("remixicon-react/EyeLineIcon"),
-);
-const EyeOffIcon = loadableForRemixIcons(
+const EyeIcon = importRemixIcon(() => import("remixicon-react/EyeLineIcon"));
+const EyeOffIcon = importRemixIcon(
   () => import("remixicon-react/EyeOffLineIcon"),
 );
-const CloseIcon = loadableForRemixIcons(
+const CloseIcon = importRemixIcon(
   () => import("remixicon-react/CloseLineIcon"),
 );
-const SubtractIcon = loadableForRemixIcons(
+const SubtractIcon = importRemixIcon(
   () => import("remixicon-react/SubtractFillIcon"),
 );
-const BookLineIcon = loadableForSvg(
+const BookLineIcon = importSvg(
   () => import("../__assets__/icons/ads/book-open-line.svg"),
 );
-const BugIcon = loadableForSvg(() => import("../__assets__/icons/ads/bug.svg"));
-const CancelIcon = loadableForSvg(
+const BugIcon = importSvg(() => import("../__assets__/icons/ads/bug.svg"));
+const CancelIcon = importSvg(
   () => import("../__assets__/icons/ads/cancel.svg"),
 );
-const CrossIcon = loadableForSvg(
-  () => import("../__assets__/icons/ads/cross.svg"),
-);
-const Fork2Icon = loadableForSvg(
-  () => import("../__assets__/icons/ads/fork-2.svg"),
-);
-const OpenIcon = loadableForSvg(
-  () => import("../__assets__/icons/ads/open.svg"),
-);
-const UserIcon = loadableForSvg(
-  () => import("../__assets__/icons/ads/user.svg"),
-);
-const GeneralIcon = loadableForSvg(
+const CrossIcon = importSvg(() => import("../__assets__/icons/ads/cross.svg"));
+const Fork2Icon = importSvg(() => import("../__assets__/icons/ads/fork-2.svg"));
+const OpenIcon = importSvg(() => import("../__assets__/icons/ads/open.svg"));
+const UserIcon = importSvg(() => import("../__assets__/icons/ads/user.svg"));
+const GeneralIcon = importSvg(
   () => import("../__assets__/icons/ads/general.svg"),
 );
-const BillingIcon = loadableForSvg(
+const BillingIcon = importSvg(
   () => import("../__assets__/icons/ads/billing.svg"),
 );
-const ErrorIcon = loadableForSvg(
-  () => import("../__assets__/icons/ads/error.svg"),
-);
-const ShineIcon = loadableForSvg(
-  () => import("../__assets__/icons/ads/shine.svg"),
-);
-const SuccessIcon = loadableForSvg(
+const ErrorIcon = importSvg(() => import("../__assets__/icons/ads/error.svg"));
+const ShineIcon = importSvg(() => import("../__assets__/icons/ads/shine.svg"));
+const SuccessIcon = importSvg(
   () => import("../__assets__/icons/ads/success.svg"),
 );
-const WarningTriangleIcon = loadableForSvg(
+const WarningTriangleIcon = importSvg(
   () => import("../__assets__/icons/ads/warning-triangle.svg"),
 );
-const ShareIcon2 = loadableForSvg(
+const ShareIcon2 = importSvg(
   () => import("../__assets__/icons/ads/share-2.svg"),
 );
-const InviteUserIcon = loadableForSvg(
+const InviteUserIcon = importSvg(
   () => import("../__assets__/icons/ads/invite-users.svg"),
 );
-const ManageIcon = loadableForSvg(
+const ManageIcon = importSvg(
   () => import("../__assets__/icons/ads/manage.svg"),
 );
-const ArrowLeft = loadableForSvg(
+const ArrowLeft = importSvg(
   () => import("../__assets__/icons/ads/arrow-left.svg"),
 );
-const ChevronLeft = loadableForSvg(
+const ChevronLeft = importSvg(
   () => import("../__assets__/icons/ads/chevron_left.svg"),
 );
-const LinkIcon = loadableForSvg(
-  () => import("../__assets__/icons/ads/link.svg"),
-);
-const NoResponseIcon = loadableForSvg(
+const LinkIcon = importSvg(() => import("../__assets__/icons/ads/link.svg"));
+const NoResponseIcon = importSvg(
   () => import("../__assets__/icons/ads/no-response.svg"),
 );
-const LightningIcon = loadableForSvg(
+const LightningIcon = importSvg(
   () => import("../__assets__/icons/ads/lightning.svg"),
 );
-const TrendingFlat = loadableForSvg(
+const TrendingFlat = importSvg(
   () => import("../__assets__/icons/ads/trending-flat.svg"),
 );
-const PlayIcon = loadableForSvg(
-  () => import("../__assets__/icons/ads/play.svg"),
-);
-const DesktopIcon = loadableForSvg(
+const PlayIcon = importSvg(() => import("../__assets__/icons/ads/play.svg"));
+const DesktopIcon = importSvg(
   () => import("../__assets__/icons/ads/desktop.svg"),
 );
-const WandIcon = loadableForSvg(
-  () => import("../__assets__/icons/ads/wand.svg"),
-);
-const MobileIcon = loadableForSvg(
+const WandIcon = importSvg(() => import("../__assets__/icons/ads/wand.svg"));
+const MobileIcon = importSvg(
   () => import("../__assets__/icons/ads/mobile.svg"),
 );
-const TabletIcon = loadableForSvg(
+const TabletIcon = importSvg(
   () => import("../__assets__/icons/ads/tablet.svg"),
 );
-const TabletLandscapeIcon = loadableForSvg(
+const TabletLandscapeIcon = importSvg(
   () => import("../__assets__/icons/ads/tablet-landscape.svg"),
 );
-const FluidIcon = loadableForSvg(
-  () => import("../__assets__/icons/ads/fluid.svg"),
-);
-const CardContextMenu = loadableForSvg(
+const FluidIcon = importSvg(() => import("../__assets__/icons/ads/fluid.svg"));
+const CardContextMenu = importSvg(
   () => import("../__assets__/icons/ads/card-context-menu.svg"),
 );
-const SendButton = loadableForSvg(
+const SendButton = importSvg(
   () => import("../__assets__/icons/comments/send-button.svg"),
 );
-const Pin = loadableForSvg(
-  () => import("../__assets__/icons/comments/pin.svg"),
-);
-const TrashOutline = loadableForSvg(
+const Pin = importSvg(() => import("../__assets__/icons/comments/pin.svg"));
+const TrashOutline = importSvg(
   () => import("../__assets__/icons/form/trash.svg"),
 );
-const ReadPin = loadableForSvg(
+const ReadPin = importSvg(
   () => import("../__assets__/icons/comments/read-pin.svg"),
 );
-const UnreadPin = loadableForSvg(
+const UnreadPin = importSvg(
   () => import("../__assets__/icons/comments/unread-pin.svg"),
 );
-const Chat = loadableForSvg(
-  () => import("../__assets__/icons/comments/chat.svg"),
-);
-const Unpin = loadableForSvg(
+const Chat = importSvg(() => import("../__assets__/icons/comments/chat.svg"));
+const Unpin = importSvg(
   () => import("../__assets__/icons/comments/unpinIcon.svg"),
 );
-const Reaction = loadableForSvg(
+const Reaction = importSvg(
   () => import("../__assets__/icons/comments/reaction.svg"),
 );
-const Reaction2 = loadableForSvg(
+const Reaction2 = importSvg(
   () => import("../__assets__/icons/comments/reaction-2.svg"),
 );
-const Upload = loadableForSvg(
-  () => import("../__assets__/icons/ads/upload.svg"),
-);
-const ArrowForwardIcon = loadableForSvg(
+const Upload = importSvg(() => import("../__assets__/icons/ads/upload.svg"));
+const ArrowForwardIcon = importSvg(
   () => import("../__assets__/icons/control/arrow_forward.svg"),
 );
-const DoubleArrowRightIcon = loadableForSvg(
+const DoubleArrowRightIcon = importSvg(
   () => import("../__assets__/icons/ads/double-arrow-right.svg"),
 );
-const CapSolidIcon = loadableForSvg(
+const CapSolidIcon = importSvg(
   () => import("../__assets__/icons/control/cap_solid.svg"),
 );
-const CapDotIcon = loadableForSvg(
+const CapDotIcon = importSvg(
   () => import("../__assets__/icons/control/cap_dot.svg"),
 );
-const LineDottedIcon = loadableForSvg(
+const LineDottedIcon = importSvg(
   () => import("../__assets__/icons/control/line_dotted.svg"),
 );
-const LineDashedIcon = loadableForSvg(
+const LineDashedIcon = importSvg(
   () => import("../__assets__/icons/control/line_dashed.svg"),
 );
-const TableIcon = loadableForSvg(
-  () => import("../__assets__/icons/ads/tables.svg"),
-);
-const ColumnIcon = loadableForSvg(
+const TableIcon = importSvg(() => import("../__assets__/icons/ads/tables.svg"));
+const ColumnIcon = importSvg(
   () => import("../__assets__/icons/ads/column.svg"),
 );
-const GearIcon = loadableForSvg(
-  () => import("../__assets__/icons/ads/gear.svg"),
-);
-const UserV2Icon = loadableForSvg(
+const GearIcon = importSvg(() => import("../__assets__/icons/ads/gear.svg"));
+const UserV2Icon = importSvg(
   () => import("../__assets__/icons/ads/user-v2.svg"),
 );
-const SupportIcon = loadableForSvg(
+const SupportIcon = importSvg(
   () => import("../__assets__/icons/ads/support.svg"),
 );
-const Snippet = loadableForSvg(
-  () => import("../__assets__/icons/ads/snippet.svg"),
-);
-const WorkspaceIcon = loadableForSvg(
+const Snippet = importSvg(() => import("../__assets__/icons/ads/snippet.svg"));
+const WorkspaceIcon = importSvg(
   () => import("../__assets__/icons/ads/workspaceIcon.svg"),
 );
-const SettingIcon = loadableForSvg(
+const SettingIcon = importSvg(
   () => import("../__assets__/icons/control/settings.svg"),
 );
-const DropdownIcon = loadableForSvg(
+const DropdownIcon = importSvg(
   () => import("../__assets__/icons/ads/dropdown.svg"),
 );
-const ChatIcon = loadableForSvg(
+const ChatIcon = importSvg(
   () => import("../__assets__/icons/ads/app-icons/chat.svg"),
 );
-const JsIcon = loadableForSvg(() => import("../__assets__/icons/ads/js.svg"));
-const ExecuteIcon = loadableForSvg(
+const JsIcon = importSvg(() => import("../__assets__/icons/ads/js.svg"));
+const ExecuteIcon = importSvg(
   () => import("../__assets__/icons/ads/execute.svg"),
 );
-const PackageIcon = loadableForSvg(
+const PackageIcon = importSvg(
   () => import("../__assets__/icons/ads/package.svg"),
 );
-const DeleteIcon = loadableForSvg(
+const DeleteIcon = importSvg(
   () => import("../__assets__/icons/control/delete.svg"),
 );
-const MoveIcon = loadableForSvg(
+const MoveIcon = importSvg(
   () => import("../__assets__/icons/control/move.svg"),
 );
-const EditIcon = loadableForSvg(
+const EditIcon = importSvg(
   () => import("../__assets__/icons/control/edit.svg"),
 );
-const ViewIcon = loadableForSvg(
+const ViewIcon = importSvg(
   () => import("../__assets__/icons/control/view.svg"),
 );
-const MoreVerticalIcon = loadableForSvg(
+const MoreVerticalIcon = importSvg(
   () => import("../__assets__/icons/control/more-vertical.svg"),
 );
-const OverflowMenuIcon = loadableForSvg(
+const OverflowMenuIcon = importSvg(
   () => import("../__assets__/icons/menu/overflow-menu.svg"),
 );
-const JsToggleIcon = loadableForSvg(
+const JsToggleIcon = importSvg(
   () => import("../__assets__/icons/control/js-toggle.svg"),
 );
-const IncreaseIcon = loadableForSvg(
+const IncreaseIcon = importSvg(
   () => import("../__assets__/icons/control/increase.svg"),
 );
-const DecreaseIcon = loadableForSvg(
+const DecreaseIcon = importSvg(
   () => import("../__assets__/icons/control/decrease.svg"),
 );
-const DraggableIcon = loadableForSvg(
+const DraggableIcon = importSvg(
   () => import("../__assets__/icons/control/draggable.svg"),
 );
-const AddCircleIcon = loadableForSvg(
+const AddCircleIcon = importSvg(
   () => import("../__assets__/icons/control/add-circle.svg"),
 );
-const HelpIcon = loadableForSvg(
+const HelpIcon = importSvg(
   () => import("../__assets__/icons/control/help.svg"),
 );
-const CollapseIcon = loadableForSvg(
+const CollapseIcon = importSvg(
   () => import("../__assets__/icons/control/collapse.svg"),
 );
-const PickMyLocationSelectedIcon = loadableForSvg(
+const PickMyLocationSelectedIcon = importSvg(
   () => import("../__assets__/icons/control/pick-location-selected.svg"),
 );
-const RemoveIcon = loadableForSvg(
+const RemoveIcon = importSvg(
   () => import("../__assets__/icons/control/remove.svg"),
 );
-const DragIcon = loadableForSvg(
+const DragIcon = importSvg(
   () => import("../__assets__/icons/control/drag.svg"),
 );
-const SortIcon = loadableForSvg(
+const SortIcon = importSvg(
   () => import("../__assets__/icons/control/sort-icon.svg"),
 );
-const EditWhiteIcon = loadableForSvg(
+const EditWhiteIcon = importSvg(
   () => import("../__assets__/icons/control/edit-white.svg"),
 );
-const LaunchIcon = loadableForSvg(
+const LaunchIcon = importSvg(
   () => import("../__assets__/icons/control/launch.svg"),
 );
-const BackIcon = loadableForSvg(
+const BackIcon = importSvg(
   () => import("../__assets__/icons/control/back.svg"),
 );
-const DeleteColumnIcon = loadableForSvg(
+const DeleteColumnIcon = importSvg(
   () => import("../__assets__/icons/control/delete-column.svg"),
 );
-const BoldFontIcon = loadableForSvg(
+const BoldFontIcon = importSvg(
   () => import("../__assets__/icons/control/bold.svg"),
 );
-const UnderlineIcon = loadableForSvg(
+const UnderlineIcon = importSvg(
   () => import("../__assets__/icons/control/underline.svg"),
 );
-const ItalicsFontIcon = loadableForSvg(
+const ItalicsFontIcon = importSvg(
   () => import("../__assets__/icons/control/italics.svg"),
 );
-const LeftAlignIcon = loadableForSvg(
+const LeftAlignIcon = importSvg(
   () => import("../__assets__/icons/control/left-align.svg"),
 );
-const CenterAlignIcon = loadableForSvg(
+const CenterAlignIcon = importSvg(
   () => import("../__assets__/icons/control/center-align.svg"),
 );
-const RightAlignIcon = loadableForSvg(
+const RightAlignIcon = importSvg(
   () => import("../__assets__/icons/control/right-align.svg"),
 );
-const VerticalAlignRight = loadableForSvg(
+const VerticalAlignRight = importSvg(
   () => import("../__assets__/icons/control/align_right.svg"),
 );
-const VerticalAlignLeft = loadableForSvg(
+const VerticalAlignLeft = importSvg(
   () => import("../__assets__/icons/control/align_left.svg"),
 );
-const VerticalAlignBottom = loadableForSvg(
+const VerticalAlignBottom = importSvg(
   () => import("../__assets__/icons/control/vertical_align_bottom.svg"),
 );
-const VerticalAlignCenter = loadableForSvg(
+const VerticalAlignCenter = importSvg(
   () => import("../__assets__/icons/control/vertical_align_center.svg"),
 );
-const VerticalAlignTop = loadableForSvg(
+const VerticalAlignTop = importSvg(
   () => import("../__assets__/icons/control/vertical_align_top.svg"),
 );
-const Copy2Icon = loadableForSvg(
+const Copy2Icon = importSvg(
   () => import("../__assets__/icons/control/copy2.svg"),
 );
-const CutIcon = loadableForSvg(
-  () => import("../__assets__/icons/control/cut.svg"),
-);
-const GroupIcon = loadableForSvg(
+const CutIcon = importSvg(() => import("../__assets__/icons/control/cut.svg"));
+const GroupIcon = importSvg(
   () => import("../__assets__/icons/control/group.svg"),
 );
-const HeadingOneIcon = loadableForSvg(
+const HeadingOneIcon = importSvg(
   () => import("../__assets__/icons/control/heading_1.svg"),
 );
-const HeadingTwoIcon = loadableForSvg(
+const HeadingTwoIcon = importSvg(
   () => import("../__assets__/icons/control/heading_2.svg"),
 );
-const HeadingThreeIcon = loadableForSvg(
+const HeadingThreeIcon = importSvg(
   () => import("../__assets__/icons/control/heading_3.svg"),
 );
-const ParagraphIcon = loadableForSvg(
+const ParagraphIcon = importSvg(
   () => import("../__assets__/icons/control/paragraph.svg"),
 );
-const ParagraphTwoIcon = loadableForSvg(
+const ParagraphTwoIcon = importSvg(
   () => import("../__assets__/icons/control/paragraph_2.svg"),
 );
-const BulletsIcon = loadableForSvg(
+const BulletsIcon = importSvg(
   () => import("../__assets__/icons/control/bullets.svg"),
 );
-const DividerCapRightIcon = loadableForSvg(
+const DividerCapRightIcon = importSvg(
   () => import("../__assets__/icons/control/divider_cap_right.svg"),
 );
-const DividerCapLeftIcon = loadableForSvg(
+const DividerCapLeftIcon = importSvg(
   () => import("../__assets__/icons/control/divider_cap_left.svg"),
 );
-const DividerCapAllIcon = loadableForSvg(
+const DividerCapAllIcon = importSvg(
   () => import("../__assets__/icons/control/divider_cap_all.svg"),
 );
-const AlignLeftIcon = loadableForSvg(
+const AlignLeftIcon = importSvg(
   () => import("../__assets__/icons/control/align_left.svg"),
 );
-const AlignRightIcon = loadableForSvg(
+const AlignRightIcon = importSvg(
   () => import("../__assets__/icons/control/align_right.svg"),
 );
-const BorderRadiusSharpIcon = loadableForSvg(
+const BorderRadiusSharpIcon = importSvg(
   () => import("../__assets__/icons/control/border-radius-sharp.svg"),
 );
-const BorderRadiusRoundedIcon = loadableForSvg(
+const BorderRadiusRoundedIcon = importSvg(
   () => import("../__assets__/icons/control/border-radius-rounded.svg"),
 );
-const BorderRadiusCircleIcon = loadableForSvg(
+const BorderRadiusCircleIcon = importSvg(
   () => import("../__assets__/icons/control/border-radius-circle.svg"),
 );
-const BoxShadowNoneIcon = loadableForSvg(
+const BoxShadowNoneIcon = importSvg(
   () => import("../__assets__/icons/control/box-shadow-none.svg"),
 );
-const BoxShadowVariant1Icon = loadableForSvg(
+const BoxShadowVariant1Icon = importSvg(
   () => import("../__assets__/icons/control/box-shadow-variant1.svg"),
 );
-const BoxShadowVariant2Icon = loadableForSvg(
+const BoxShadowVariant2Icon = importSvg(
   () => import("../__assets__/icons/control/box-shadow-variant2.svg"),
 );
-const BoxShadowVariant3Icon = loadableForSvg(
+const BoxShadowVariant3Icon = importSvg(
   () => import("../__assets__/icons/control/box-shadow-variant3.svg"),
 );
-const BoxShadowVariant4Icon = loadableForSvg(
+const BoxShadowVariant4Icon = importSvg(
   () => import("../__assets__/icons/control/box-shadow-variant4.svg"),
 );
-const BoxShadowVariant5Icon = loadableForSvg(
+const BoxShadowVariant5Icon = importSvg(
   () => import("../__assets__/icons/control/box-shadow-variant5.svg"),
 );
-const JsToggleV2 = loadableForSvg(
+const JsToggleV2 = importSvg(
   () => import("../__assets__/icons/ads/js-toggle-v2.svg"),
 );
 
@@ -1021,7 +971,7 @@ export function IconProvider(props: {
 
   const Icon = ICON_LOOKUP[iconName as keyof typeof ICON_LOOKUP]
     ? ICON_LOOKUP[iconName as keyof typeof ICON_LOOKUP]
-    : loadableForRemixIcons(
+    : importRemixIcon(
         () => import(`remixicon-react/${pascalCaseIconName}Icon`),
       );
   return Icon && <Icon color={color} size={size} />;

--- a/packages/design-system/src/Icon/loadables.tsx
+++ b/packages/design-system/src/Icon/loadables.tsx
@@ -1,24 +1,43 @@
+// IMPORTANT: please keep this file in sync with packages/design-system-old/src/utils/icon-loadables.tsx.
+
 import React from "react";
 import loadable from "@loadable/component";
-import { RemixiconReactIconComponentType } from "remixicon-react";
+import {
+  RemixiconReactIconProps,
+  RemixiconReactIconComponentType,
+} from "remixicon-react";
 
-// Using `<svg />` as a loading fallback – to make sure sizes set by <IconContainer>
-// apply even while the full icon is still loading.
-const LOADING_FALLBACK = <svg />;
+function loadableForIconImpl(
+  importFn: () => Promise<any>,
+  options?: {
+    resolveComponent: (m: any) => React.ComponentType;
+  },
+) {
+  const IconLoader = loadable.lib(importFn, options as any);
+
+  return function AppsmithLoadable(props: any) {
+    return (
+      // Using `<svg />` as a loading fallback – to make sure sizes set by <IconWrapper>
+      // apply even while the full icon is still loading.
+      // And passing all props – if the parent component sets `width` or `height`,
+      // we want to make sure it’s applied to the loading fallback as well.
+      <IconLoader fallback={<svg {...props} />}>
+        {(Icon: React.ComponentType) => <Icon {...props} />}
+      </IconLoader>
+    );
+  };
+}
 
 export function loadableForSvg(
   importFn: () => Promise<typeof import("*.svg")>,
-) {
-  return loadable(importFn, {
-    resolveComponent: (m) => m.ReactComponent,
-    fallback: LOADING_FALLBACK,
+): React.ComponentType<React.SVGProps<SVGSVGElement>> {
+  return loadableForIconImpl(importFn, {
+    resolveComponent: (m: typeof import("*.svg")) => m.ReactComponent,
   });
 }
 
 export function loadableForRemixIcons(
   importFn: () => Promise<{ default: RemixiconReactIconComponentType }>,
-) {
-  return loadable(importFn, {
-    fallback: LOADING_FALLBACK,
-  });
+): React.ComponentType<RemixiconReactIconProps> {
+  return loadableForIconImpl(importFn);
 }

--- a/packages/design-system/src/Icon/loadables.tsx
+++ b/packages/design-system/src/Icon/loadables.tsx
@@ -7,7 +7,7 @@ import {
   RemixiconReactIconComponentType,
 } from "remixicon-react";
 
-function loadableForIconImpl(
+function importIconImpl(
   importFn: () => Promise<any>,
   options?: {
     resolveComponent: (m: any) => React.ComponentType;
@@ -28,16 +28,16 @@ function loadableForIconImpl(
   };
 }
 
-export function loadableForSvg(
+export function importSvg(
   importFn: () => Promise<typeof import("*.svg")>,
 ): React.ComponentType<React.SVGProps<SVGSVGElement>> {
-  return loadableForIconImpl(importFn, {
+  return importIconImpl(importFn, {
     resolveComponent: (m: typeof import("*.svg")) => m.ReactComponent,
   });
 }
 
-export function loadableForRemixIcons(
+export function importRemixIcon(
   importFn: () => Promise<{ default: RemixiconReactIconComponentType }>,
 ): React.ComponentType<RemixiconReactIconProps> {
-  return loadableForIconImpl(importFn);
+  return importIconImpl(importFn);
 }

--- a/packages/design-system/src/Icon/loadables.tsx
+++ b/packages/design-system/src/Icon/loadables.tsx
@@ -1,19 +1,15 @@
 // IMPORTANT: please keep this file in sync with packages/design-system-old/src/utils/icon-loadables.tsx.
 
-import React from "react";
-import loadable from "@loadable/component";
+import React, { Suspense } from "react";
 import {
   RemixiconReactIconProps,
   RemixiconReactIconComponentType,
 } from "remixicon-react";
 
 function importIconImpl(
-  importFn: () => Promise<any>,
-  options?: {
-    resolveComponent: (m: any) => React.ComponentType;
-  },
+  importFn: () => Promise<{ default: React.ComponentType }>,
 ) {
-  const IconLoader = loadable.lib(importFn, options as any);
+  const Icon = React.lazy(importFn);
 
   return function AppsmithLoadable(props: any) {
     return (
@@ -21,9 +17,9 @@ function importIconImpl(
       // apply even while the full icon is still loading.
       // And passing all props – if the parent component sets `width` or `height`,
       // we want to make sure it’s applied to the loading fallback as well.
-      <IconLoader fallback={<svg {...props} />}>
-        {(Icon: React.ComponentType) => <Icon {...props} />}
-      </IconLoader>
+      <Suspense fallback={<svg {...props} />}>
+        <Icon {...props} />
+      </Suspense>
     );
   };
 }
@@ -31,9 +27,9 @@ function importIconImpl(
 export function importSvg(
   importFn: () => Promise<typeof import("*.svg")>,
 ): React.ComponentType<React.SVGProps<SVGSVGElement>> {
-  return importIconImpl(importFn, {
-    resolveComponent: (m: typeof import("*.svg")) => m.ReactComponent,
-  });
+  return importIconImpl(() =>
+    importFn().then((m) => ({ default: m.ReactComponent })),
+  );
 }
 
 export function importRemixIcon(

--- a/packages/design-system/src/Icon/loadables.tsx
+++ b/packages/design-system/src/Icon/loadables.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import loadable from "@loadable/component";
+import { RemixiconReactIconComponentType } from "remixicon-react";
+
+// Using `<svg />` as a loading fallback – to make sure sizes set by <IconContainer>
+// apply even while the full icon is still loading.
+const LOADING_FALLBACK = <svg />;
+
+export function loadableForSvg(
+  importFn: () => Promise<typeof import("*.svg")>,
+) {
+  return loadable(importFn, {
+    resolveComponent: (m) => m.ReactComponent,
+    fallback: LOADING_FALLBACK,
+  });
+}
+
+export function loadableForRemixIcons(
+  importFn: () => Promise<{ default: RemixiconReactIconComponentType }>,
+) {
+  return loadable(importFn, {
+    fallback: LOADING_FALLBACK,
+  });
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1916,7 +1916,7 @@
   dependencies:
     regenerator-runtime "^0.13.11"
 
-"@babel/runtime@^7.12.13":
+"@babel/runtime@^7.12.13", "@babel/runtime@^7.7.7":
   version "7.21.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.21.0.tgz#5b55c9d394e5fcf304909a8b00c07dc217b56673"
   integrity sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==
@@ -3112,6 +3112,15 @@
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/@juggle/resize-observer/-/resize-observer-3.3.1.tgz#b50a781709c81e10701004214340f25475a171a0"
   integrity sha512-zMM9Ds+SawiUkakS7y94Ymqx+S0ORzpG3frZirN3l+UlXUmSUR7hF4wxCVqW+ei94JzV5kt0uXBcoOEAuiydrw==
+
+"@loadable/component@^5.15.3":
+  version "5.15.3"
+  resolved "https://registry.yarnpkg.com/@loadable/component/-/component-5.15.3.tgz#7de7dcbdbf3db3799bf48d58cfcbae7a18d1818c"
+  integrity sha512-VOgYgCABn6+/7aGIpg7m0Ruj34tGetaJzt4bQ345FwEovDQZ+dua+NWLmuJKv8rWZyxOUSfoJkmGnzyDXH2BAQ==
+  dependencies:
+    "@babel/runtime" "^7.7.7"
+    hoist-non-react-statics "^3.3.1"
+    react-is "^16.12.0"
 
 "@manypkg/find-root@^1.1.0":
   version "1.1.0"
@@ -6662,6 +6671,13 @@
   dependencies:
     "@types/fined" "*"
     "@types/node" "*"
+
+"@types/loadable__component@^5.13.4":
+  version "5.13.4"
+  resolved "https://registry.yarnpkg.com/@types/loadable__component/-/loadable__component-5.13.4.tgz#a4646b2406b1283efac1a9d9485824a905b33d4a"
+  integrity sha512-YhoCCxyuvP2XeZNbHbi8Wb9EMaUJuA2VGHxJffcQYrJKIKSkymJrhbzsf9y4zpTmr5pExAAEh5hbF628PAZ8Dg==
+  dependencies:
+    "@types/react" "*"
 
 "@types/lodash-es@^4.17.6":
   version "4.17.6"
@@ -12085,7 +12101,7 @@ hmac-drbg@^1.0.1:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.2.1, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
+hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.2.1, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.1, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -19092,10 +19108,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-typescript@4.5.5:
-  version "4.5.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.5.tgz#d8c953832d28924a9e3d37c73d729c846c5896f3"
-  integrity sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==
+typescript@4.9.5:
+  version "4.9.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
+  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
 
 uglify-js@^3.1.4:
   version "3.16.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1916,7 +1916,7 @@
   dependencies:
     regenerator-runtime "^0.13.11"
 
-"@babel/runtime@^7.12.13", "@babel/runtime@^7.7.7":
+"@babel/runtime@^7.12.13":
   version "7.21.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.21.0.tgz#5b55c9d394e5fcf304909a8b00c07dc217b56673"
   integrity sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==
@@ -3112,15 +3112,6 @@
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/@juggle/resize-observer/-/resize-observer-3.3.1.tgz#b50a781709c81e10701004214340f25475a171a0"
   integrity sha512-zMM9Ds+SawiUkakS7y94Ymqx+S0ORzpG3frZirN3l+UlXUmSUR7hF4wxCVqW+ei94JzV5kt0uXBcoOEAuiydrw==
-
-"@loadable/component@^5.15.3":
-  version "5.15.3"
-  resolved "https://registry.yarnpkg.com/@loadable/component/-/component-5.15.3.tgz#7de7dcbdbf3db3799bf48d58cfcbae7a18d1818c"
-  integrity sha512-VOgYgCABn6+/7aGIpg7m0Ruj34tGetaJzt4bQ345FwEovDQZ+dua+NWLmuJKv8rWZyxOUSfoJkmGnzyDXH2BAQ==
-  dependencies:
-    "@babel/runtime" "^7.7.7"
-    hoist-non-react-statics "^3.3.1"
-    react-is "^16.12.0"
 
 "@manypkg/find-root@^1.1.0":
   version "1.1.0"
@@ -12101,7 +12092,7 @@ hmac-drbg@^1.0.1:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.2.1, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.1, hoist-non-react-statics@^3.3.2:
+hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.2.1, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==


### PR DESCRIPTION
This PR is easier to review commit-by-commit.

## Description

This pull request
- code-splits all `.svg` and `remix` icons away, while retailing their styleability
- and sets up reusable `importSvg` and `importRemix` wrappers for code-splitting icons (I’m happy to bikeshed on the name if you have better ideas!)

### Why this is needed

Traditionally, in HTML, there are two ways to handle SVG graphics:
- one is to emit every SVG image as a separate `.svg` file – and then use the `<img>` tag to load it
- and another one is to render every SVG straight into HTML, using the `<svg>` tag

The second approach is more powerful, as it allows to style SVG images with CSS. However, in client-rendered apps, it also means bundling every SVG image into the bundle, as it’s _the bundle_ that generates HTML and must know how to render SVGs into it.

That’s the issue Appsmith had:

![Muse MuseImage 2023-03-15 11 47 37](https://user-images.githubusercontent.com/2953267/225287183-0b033ccf-1187-4efe-b000-9e03b4a0cd35.png)

The Appsmith product uses both its own `.svg` icons and `remixicon-react` icons. Each of these icons is imported as a React component, which is great for styling reasons but not great for the bundle size. In the screenshot above, the highlighted parts add up to ~0.8 MB minified. 

### How this is solved

The key goal of this solution was to:
- load icons on-demand, as if they were `.svg` files
- but want to allow to style these icons with css, as if they were inline `<svg>` tags

To achieve this, the solutions
- code-splits every icon away using `import()`
- sets up a wrapper (`importSvg` and `importRemix`) around every icon that preserves the icon’s size while the icon is loading

With this solution, the icons start loading as soon as they’re rendered. And the UI doesn’t jump during loading at all, as all the `width/height` styles and props are preserved on the loading fallback.


## Type of change

- Chore (housekeeping or task changes that don't impact user perception)

## How Has This Been Tested?

- Manual on main repo

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
