### PR TITLE
fix: divider width and color

### DIFF
--- a/.changeset/cool-flies-perform.md
+++ b/.changeset/cool-flies-perform.md
@@ -1,0 +1,5 @@
+---
+"@appsmithorg/design-system": patch
+---
+
+fix: divider width and color

--- a/packages/design-system/src/Divider/Divider.styles.tsx
+++ b/packages/design-system/src/Divider/Divider.styles.tsx
@@ -10,14 +10,10 @@ export const StyledDivider = styled.span<{
 }>`
   ${Variables};
 
-  background-color: var(--ads-v2-color-border);
-  width: ${(props) =>
+  ${(props) =>
     props.orientation === "horizontal"
-      ? "var(--divider-length)"
-      : "var(--divider-thickness)"};
-  height: ${(props) =>
-    props.orientation === "horizontal"
-      ? "var(--divider-thickness)"
-      : "var(--divider-length)"};
+      ? "border-top: var(--divider-thickness) solid var(--ads-v2-color-border); width: var(--divider-length);"
+      : "border-left: var(--divider-thickness) solid var(--ads-v2-color-border); height: var(--divider-length);"}
+
   display: inline-block;
 `;


### PR DESCRIPTION
## Description

Fixes issue with divider looking starkly different from borders because divider was implemented using a div, despite using the same colors and dimensions. 

Before: 
<img width="408" alt="Screenshot 2023-03-29 at 9 36 34 AM" src="https://user-images.githubusercontent.com/13763558/228424554-ee7ec609-0a12-47a3-800e-a02e89b4f122.png">

After: 
<img width="369" alt="Screenshot 2023-03-29 at 9 15 52 AM" src="https://user-images.githubusercontent.com/13763558/228424569-255bd46a-74a9-46cb-bb87-0a5de50feb06.png">

This is important because sometimes we use dividers and borders interchangably.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Manual on storybook 
- Manual on main repo

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
