### PR TITLE
fix: Adding autoResetExpanded to the table component for avoiding the tree getting closed on every change

### DIFF
--- a/packages/design-system-old/src/Table/index.tsx
+++ b/packages/design-system-old/src/Table/index.tsx
@@ -160,7 +160,11 @@ function Table(props: TableProps) {
     headerGroups,
     prepareRow,
     rows,
-  } = useTable({ columns, data }, useSortBy, useExpanded);
+  } = useTable(
+    { autoResetExpanded: false, columns, data },
+    useSortBy,
+    useExpanded,
+  );
 
   return (
     <Styles>


### PR DESCRIPTION
## Description

> Adding autoResetExpanded to the table component for avoiding the tree getting closed on every change.

Fixes [#22033](https://github.com/appsmithorg/appsmith/issues/22033)

Depends on # (pr)
> every PR in the design-system repository should have a corresponding PR in the appsmith repository to ensure that changes 
> here don't break existing flows. Link the corresponding PR here to trigger dpulls and prevent accidental merging.
> If relevant, link the enterprise PR here as well.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Manual on main repo

## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
