### PR TITLE
chore: Importing and adding the external link line icon from remixicon

### DIFF
--- a/.changeset/tasty-lamps-cover.md
+++ b/.changeset/tasty-lamps-cover.md
@@ -1,0 +1,6 @@
+---
+"@appsmithorg/design-system-old": patch
+"@appsmithorg/design-system": patch
+---
+
+chore: Importing and adding the external link line icon from remixicon

--- a/.changeset/tasty-lamps-cover.md
+++ b/.changeset/tasty-lamps-cover.md
@@ -1,5 +1,4 @@
 ---
-"@appsmithorg/design-system-old": patch
 "@appsmithorg/design-system": patch
 ---
 

--- a/packages/design-system-old/src/Icon/index.tsx
+++ b/packages/design-system-old/src/Icon/index.tsx
@@ -497,6 +497,9 @@ const ArrowUpLineIcon = importRemixIcon(() =>
 const MoneyDollarCircleLineIcon = importRemixIcon(() =>
   import("remixicon-react/MoneyDollarCircleLineIcon"),
 );
+const ExternalLinkLineIcon = importRemixIcon(() =>
+  import("remixicon-react/ExternalLinkLineIcon"),
+);
 
 export enum IconSize {
   XXS = "extraExtraSmall",
@@ -630,6 +633,7 @@ const ICON_LOOKUP = {
   "edit-underline": <EditUnderlineIcon />,
   "expand-less": <ExpandLess />,
   "expand-more": <ExpandMore />,
+  "external-link-line": <ExternalLinkLineIcon />,
   "eye-off": <EyeOff />,
   "eye-on": <EyeOn />,
   "file-line": <FileLine />,


### PR DESCRIPTION
## Description

> Importing and adding the external link line icon from remixicon to use in the invite modal for the upgrade button.

Fixes [#20578](https://github.com/appsmithorg/appsmith/issues/20578)

Depends on # (pr)
> every PR in the design-system repository should have a corresponding PR in the appsmith repository to ensure that changes 
> here don't break existing flows. Link the corresponding PR here to trigger dpulls and prevent accidental merging.
> If relevant, link the enterprise PR here as well.

## Type of change

- Chore (housekeeping or task changes that don't impact user perception)

## How Has This Been Tested?
- Manual on storybook 
- Manual on main repo

## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
