### PR TITLE
chore: give control to user to enable/disable uppy informer

### DIFF
--- a/.changeset/hot-foxes-tickle.md
+++ b/.changeset/hot-foxes-tickle.md
@@ -1,0 +1,6 @@
+---
+"@appsmithorg/design-system-old": patch
+"@appsmithorg/design-system": patch
+---
+
+chore: give control to user to enable/disable uppy informer

--- a/packages/design-system-old/src/DisplayImageUpload/index.tsx
+++ b/packages/design-system-old/src/DisplayImageUpload/index.tsx
@@ -29,6 +29,7 @@ type Props = {
   submit: (uppy: Uppy.Uppy) => void;
   value: string;
   label?: string;
+  disableUppyInformer?: boolean;
 };
 
 const Container = styled.div`
@@ -77,6 +78,7 @@ export default function DisplayImageUpload({
   onRemove,
   submit,
   value,
+  disableUppyInformer,
 }: Props) {
   const [loadError, setLoadError] = useState(false);
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -200,6 +202,7 @@ export default function DisplayImageUpload({
           note="File size must not exceed 3 MB"
           plugins={["ImageEditor"]}
           uppy={uppy}
+          disableInformer={disableUppyInformer}
         />
       </Dialog>
     </Container>


### PR DESCRIPTION
## Description

- Since we are using uppy in `DisplayImageUpload` component and not exposing a way for the user to control what `options` they want with uppy, for airgapped instances we want to disable the informer which show `No internet connection`. 
- So just gave control to user for that particular option alone. 

Fixes #463 
> if no issue exists, please create an issue and ask the maintainers about this first

Media:

https://user-images.githubusercontent.com/74818788/233578785-d43b89d5-39b4-4300-912e-46c0539727a6.mov



Depends on [#22366](https://github.com/appsmithorg/appsmith/issues/22366)

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- Chore (housekeeping or task changes that don't impact user perception)


## How Has This Been Tested?

- Manual on main repo

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
