### PR TITLE
fix: Updating the click action on input label to remove focus from input box

### DIFF
--- a/.changeset/kind-pugs-dress.md
+++ b/.changeset/kind-pugs-dress.md
@@ -1,0 +1,5 @@
+---
+"@appsmithorg/design-system": patch
+---
+
+fix: Updating the click action on input label to remove focus from input box

--- a/packages/design-system/src/Input/Input.tsx
+++ b/packages/design-system/src/Input/Input.tsx
@@ -83,7 +83,11 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
         text is throwing typescript error.
         https://stackoverflow.com/questions/68073958/cant-use-href-with-iconbuttonprops*/}
         {label && (
-          <Label {...labelProps} className={InputLabelClassName}>
+          <Label
+            {...labelProps}
+            className={InputLabelClassName}
+            onClick={(e) => e.preventDefault()}
+          >
             {label}
             {/* Show required star only if label is present */}
             {label && isRequired && <span>*</span>}


### PR DESCRIPTION
## Description

Updating the click action on input label to remove focus from input box

Fixes https://www.notion.so/appsmith/Clicking-next-to-the-Input-labels-does-not-remove-focus-from-inputs-a5a7f50c71d941998b1d0a11380ea19f?pvs=4

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manual on storybook 

## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
