### PR TITLE
fix: Updating CSS for tooltip to fix position shift issue

### DIFF
--- a/.changeset/tasty-ears-fly.md
+++ b/.changeset/tasty-ears-fly.md
@@ -1,0 +1,6 @@
+---
+"@appsmithorg/design-system-old": patch
+"@appsmithorg/design-system": patch
+---
+
+fix: Updating CSS for tooltip to fix position shift issue

--- a/packages/design-system/src/Tooltip/Tooltip.css
+++ b/packages/design-system/src/Tooltip/Tooltip.css
@@ -1,12 +1,12 @@
 /* TODO: Find a better way to style */
 /* wrapping in styled component is not working anymore */
-.ads-v2-tooltip {
+.rc-tooltip.ads-v2-tooltip {
   --tooltip-background-color: var(--ads-v2-color-bg-emphasis-max);
   --tooltip-color: var(--ads-v2-color-fg-on-emphasis-max);
 
   /* This is important because the styles is getting overridden by main repo */
-  opacity: 1 !important;
-  z-index: 100000 !important;
+  opacity: 1;
+  z-index: 100000;
   max-width: 300px;
   overflow: hidden;
   overflow-wrap: break-word;


### PR DESCRIPTION
## Description

Updating CSS for tooltip to fix position shift issue

Fixes https://www.notion.so/appsmith/First-time-Tooltip-position-is-undesirable-833215bf50a548dd836303835ae02d46?pvs=4

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manual on storybook 
- Manual on main repo

## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
