### PR TITLE
fix: Adding a max with to modal

### DIFF
--- a/packages/design-system/src/Modal/Modal.styles.tsx
+++ b/packages/design-system/src/Modal/Modal.styles.tsx
@@ -49,6 +49,7 @@ export const StyledContent = styled(Content)`
   display: flex;
   flex-direction: column;
   z-index: 1001;
+  max-width: 640px;
 `;
 
 export const StyledHeader = styled.div`


### PR DESCRIPTION
## Description

Adding a max with to modal

Fixes https://www.notion.so/appsmith/Add-widths-to-modal-current-modal-implemented-modal-looks-large-on-larger-screen-972c227840134904987d7d4e0e540dcc?pvs=4

## Type of change
- Chore (housekeeping or task changes that don't impact user perception)

## How Has This Been Tested?
- Manual on storybook 

## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
