### PR TITLE
fix: Search input focus issue and select styles specificity

### DIFF
--- a/.changeset/fifty-birds-occur.md
+++ b/.changeset/fifty-birds-occur.md
@@ -1,0 +1,5 @@
+---
+"@appsmithorg/design-system": patch
+---
+
+fix: Search input focus issue and select styles specificity

--- a/packages/design-system/src/SearchInput/SearchInput.tsx
+++ b/packages/design-system/src/SearchInput/SearchInput.tsx
@@ -1,14 +1,20 @@
-import React, { useState, forwardRef } from "react";
+import React, { useState, forwardRef, useEffect } from "react";
 import clsx from "classnames";
 
 import { SearchInputProps } from "./SearchInput.types";
 import { StyledSearchInput } from "./SearchInput.styles";
 import { SearchInputClassName } from "./SearchInput.constants";
+import { useDOMRef } from "Hooks/useDomRef";
 
 const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
   (props, ref): JSX.Element => {
     const { className, onChange, placeholder, size = "sm", ...rest } = props;
-    const [value, setValue] = useState<string>(props.value || "");
+    const [value, setValue] = useState<string>("");
+    const inputRef = useDOMRef(ref);
+
+    useEffect(() => {
+      setValue(props.value || "");
+    }, [props.value]);
 
     const handleChange = (val: string) => {
       setValue(val);
@@ -20,10 +26,15 @@ const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
         {...rest}
         className={clsx(SearchInputClassName, className)}
         endIcon={value ? "close-circle-line" : undefined}
-        endIconProps={{ onClick: () => handleChange("") }}
+        endIconProps={{
+          onClick: () => {
+            handleChange("");
+            inputRef.current?.focus();
+          },
+        }}
         onChange={handleChange}
         placeholder={placeholder || "Search"}
-        ref={ref}
+        ref={inputRef}
         renderAs="input"
         size={size}
         startIcon="search-line"

--- a/packages/design-system/src/Select/styles.css
+++ b/packages/design-system/src/Select/styles.css
@@ -206,7 +206,8 @@
   margin-bottom: var(--ads-v2-spaces-1);
   border-radius: var(--ads-v2-border-radius);
   cursor: pointer;
-  background-color: var(--select-option-color-bg);
+  /* TODO: remove !important after WDS fix their issue in tree select */
+  background-color: var(--select-option-color-bg) !important;
   position: relative;
   color: var(--ads-v2-color-fg);
   min-height: var(--select-option-height);

--- a/packages/design-system/src/Select/styles.css
+++ b/packages/design-system/src/Select/styles.css
@@ -195,7 +195,7 @@
 }
 
 /* Option */
-.ads-v2-select__dropdown .rc-select-item {
+.ads-v2-select__dropdown .rc-select-item.rc-select-item-option {
   --select-option-padding: var(--ads-v2-spaces-3);
   --select-option-gap: var(--ads-v2-spaces-3);
   --select-option-color-bg: var(--ads-v2-color-bg);
@@ -230,7 +230,7 @@
 }
 
 /* Item content */
-.ads-v2-select__dropdown .rc-select-item .rc-select-item-option-content {
+.ads-v2-select__dropdown .rc-select-item.rc-select-item-option .rc-select-item-option-content {
   display: flex;
   align-items: center;
   gap: var(--select-option-gap);
@@ -241,32 +241,32 @@
 }
 
 /* Option hover */
-.ads-v2-select__dropdown .rc-select-item:hover,
-.ads-v2-select__dropdown .rc-select-item.rc-select-item-option-active {
+.ads-v2-select__dropdown .rc-select-item.rc-select-item-option:hover,
+.ads-v2-select__dropdown .rc-select-item.rc-select-item-option.rc-select-item-option-active {
   --select-option-color-bg: var(--ads-v2-color-bg-subtle);
   outline: none;
 }
 
 /* Option focus */
-.ads-v2-select__dropdown .rc-select-item:focus {
+.ads-v2-select__dropdown .rc-select-item.rc-select-item-option:focus {
   --select-option-color-bg: var(--ads-v2-color-bg-subtle);
   outline: none;
 }
 
 /* Option focus visible */
-.ads-v2-select__dropdown .rc-select-item:focus-visible {
+.ads-v2-select__dropdown .rc-select-item.rc-select-item-option:focus-visible {
   outline: var(--ads-v2-border-width-outline) solid
       var(--ads-v2-color-outline);
   outline-offset: var(--ads-v2-offset-outline);
 }
 
 /* Option active */
-.ads-v2-select__dropdown .rc-select-item:active {
+.ads-v2-select__dropdown .rc-select-item.rc-select-item-option:active {
   --select-option-color-bg: var(--ads-v2-color-bg-muted);
 }
 
 /* Option disabled */
-.ads-v2-select__dropdown .rc-select-item.rc-select-item-option-disabled {
+.ads-v2-select__dropdown .rc-select-item.rc-select-item-option.rc-select-item-option-disabled {
   --select-option-color-bg: var(--ads-v2-color-bg);
   opacity: var(--ads-v2-opacity-disabled);
   cursor: not-allowed;
@@ -280,6 +280,6 @@
 }
 
 /* Selected option */
-.ads-v2-select__dropdown .rc-select-item.rc-select-item-option-selected {
+.ads-v2-select__dropdown .rc-select-item.rc-select-item-option.rc-select-item-option-selected {
   --select-option-color-bg: var(--ads-v2-color-bg-muted);
 }


### PR DESCRIPTION
## Description

What this PR fixes:
1. Search input, after clicking on clear icon, looses the focus.
2. Select component option styles was getting overridden by WDS tree select component.

Fixes [#24475](https://github.com/appsmithorg/appsmith/issues/24475), [#24459](https://github.com/appsmithorg/appsmith/issues/24459)

## Media

https://github.com/appsmithorg/design-system/assets/87797149/92f99d08-a4c4-4ea3-a57f-2000bea62a62


## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Provide instructions, so we can reproduce.
> Please also list any relevant details for your test configuration.
> Delete anything that is not important

- Manual on storybook 
- Manual on main repo
- Jest
- Cypress

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
