### PR TITLE
perf(DisplayImageUpload): code-split Uppy away

### DIFF
--- a/.changeset/selfish-ducks-march.md
+++ b/.changeset/selfish-ducks-march.md
@@ -1,0 +1,5 @@
+---
+"@appsmithorg/design-system-old": patch
+---
+
+perf(DisplayImageUpload): code-split Uppy away

--- a/packages/design-system-old/src/DisplayImageUpload/Dashboard.tsx
+++ b/packages/design-system-old/src/DisplayImageUpload/Dashboard.tsx
@@ -1,0 +1,151 @@
+import React from "react";
+import Uppy from "@uppy/core";
+import { Dashboard as UppyDashboard, useUppy } from "@uppy/react";
+import ImageEditor from "@uppy/image-editor";
+import "@uppy/core/dist/style.css";
+import "@uppy/dashboard/dist/style.css";
+import "@uppy/image-editor/dist/style.css";
+import "@blueprintjs/popover2/lib/css/blueprint-popover2.css";
+
+type DashboardProps = {
+  onChange: (file: File) => void;
+  onInvalidFileContent?: () => void;
+  submit: (uppy: Uppy.Uppy) => void;
+  disableUppyInformer?: boolean;
+  onModalCloseRequested: () => void;
+};
+
+function Dashboard({
+  disableUppyInformer,
+  onChange,
+  onInvalidFileContent,
+  submit,
+  onModalCloseRequested,
+}: DashboardProps) {
+  const uppy = useUppy(() => {
+    const uppy = Uppy({
+      id: "uppy",
+      autoProceed: false,
+      allowMultipleUploads: false,
+      restrictions: {
+        maxNumberOfFiles: 1,
+        maxFileSize: 3145728, // 3 MB
+        /* Even this doesn't verify file content
+        e.g. when you rename a .json to .png and try to upload it */
+        allowedFileTypes: ["image/jpg", "image/jpeg", "image/png"],
+      },
+      infoTimeout: 5000,
+      locale: {
+        strings: {},
+      },
+    });
+
+    uppy.setOptions({
+      locale: {
+        strings: {
+          cancel: "Cancel",
+          done: "Cancel",
+        },
+      },
+    });
+
+    uppy.use(ImageEditor, {
+      id: "ImageEditor",
+      quality: 0.3,
+      cropperOptions: {
+        viewMode: 1,
+        aspectRatio: 1,
+        background: false,
+        responsive: true,
+        autoCropArea: 0.8,
+        autoCrop: true,
+      },
+      actions: {
+        revert: false,
+        rotate: false,
+        flip: false,
+        zoomIn: false,
+        zoomOut: false,
+        cropSquare: false,
+        cropWidescreen: false,
+        cropWidescreenVertical: false,
+      },
+    });
+
+    uppy.on("file-added", (file: File) => {
+      isFileContentAnImageType(file)
+        .then(() => {
+          onChange(file);
+          // TO trigger edit modal
+          const dashboard = uppy.getPlugin("uppy-img-upload-dashboard");
+          setTimeout(() => {
+            (dashboard as any).openFileEditor(file);
+          });
+        })
+        .catch(() => {
+          uppy.removeFile(uppy.getFiles()[0].id);
+          onInvalidFileContent?.();
+        });
+    });
+
+    uppy.on("upload", () => {
+      submit(uppy);
+      onModalCloseRequested();
+    });
+
+    uppy.on("file-editor:complete", (updatedFile) => {
+      onChange(updatedFile);
+    });
+
+    return uppy;
+  });
+
+  return (
+    <UppyDashboard
+      id="uppy-img-upload-dashboard"
+      note="File size must not exceed 3 MB"
+      plugins={["ImageEditor"]}
+      uppy={uppy}
+      disableInformer={disableUppyInformer}
+    />
+  );
+}
+
+export default Dashboard;
+
+const isFileContentAnImageType = (file: File) => {
+  // ref: https://stackoverflow.com/questions/18299806/how-to-check-file-mime-type-with-javascript-before-upload
+  return new Promise((resolve, reject) => {
+    // get first 4 bytes of the file
+    const blob = (file as any).data.slice(0, 4);
+    const reader = new FileReader();
+    reader.onloadend = () => {
+      if (reader.result) {
+        // convert content to a unsigned int array to read it's value
+        // then toString(16) converts to hexadecimal
+        const initialBytesOfFile = new Uint8Array(
+          reader.result as ArrayBufferLike,
+        ).reduce((prev, curr) => prev + curr.toString(16), "");
+        /*
+          compare initialBytesOfFile with magic numbers to identify file signature
+          file signatures reference: https://en.wikipedia.org/wiki/List_of_file_signatures
+        */
+        switch (initialBytesOfFile) {
+          // image/png
+          case "89504e47":
+            resolve(true);
+            break;
+          // image/jpeg or image/jpg
+          case "ffd8ffe0":
+          case "ffd8ffe1":
+          case "ffd8ffdb":
+          case "ffd8ffee":
+            resolve(true);
+            break;
+        }
+        reject();
+      }
+    };
+    reader.readAsArrayBuffer(blob);
+  });
+};

--- a/packages/design-system-old/src/DisplayImageUpload/index.tsx
+++ b/packages/design-system-old/src/DisplayImageUpload/index.tsx
@@ -163,7 +163,12 @@ const StyledDialog = styled(Dialog)`
 `;
 
 const SpinnerContainer = styled.div`
-  margin: 40px 0;
+  // Setting a concrete width and height to match the dashboard’s width and height
+  // and prevent a big layout jump when the dashboard loads
+  width: 750px;
+  height: 550px;
+  max-width: 100%;
+  max-height: 100%;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/packages/design-system-old/src/DisplayImageUpload/index.tsx
+++ b/packages/design-system-old/src/DisplayImageUpload/index.tsx
@@ -1,31 +1,24 @@
-import React, { useEffect, useState } from "react";
-import Uppy from "@uppy/core";
+import React, { Suspense, useEffect, useState } from "react";
 import Dialog from "DialogComponent";
 
-import { Dashboard, useUppy } from "@uppy/react";
-
 import styled from "styled-components";
-import ImageEditor from "@uppy/image-editor";
 import {
   REMOVE,
   createMessage,
   DISPLAY_IMAGE_UPLOAD_LABEL,
 } from "Constants/messages";
 
-import "@uppy/core/dist/style.css";
-import "@uppy/dashboard/dist/style.css";
-import "@uppy/image-editor/dist/style.css";
-import "@blueprintjs/popover2/lib/css/blueprint-popover2.css";
 import { getTypographyByKey } from "Constants/typography";
-import { importSvg } from "Utils/icon-loadables";
 
 import { ReactComponent as ProfileImagePlaceholder } from "../assets/icons/others/profile-placeholder.svg";
+import Spinner from "Spinner";
+import { IconSize } from "Icon";
 
 type Props = {
   onChange: (file: File) => void;
   onRemove?: () => void;
   onInvalidFileContent?: () => void;
-  submit: (uppy: Uppy.Uppy) => void;
+  submit: (uppy: import("@uppy/core").Uppy) => void;
   value: string;
   label?: string;
   disableUppyInformer?: boolean;
@@ -168,6 +161,16 @@ const StyledDialog = styled(Dialog)`
     color: var(--ads-v2-color-bg-emphasis-max);
   }
 `;
+
+const SpinnerContainer = styled.div`
+  margin: 40px 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+const DashboardLazy = React.lazy(() => import("./Dashboard"));
+
 export default function DisplayImageUpload({
   onChange,
   onRemove,
@@ -178,83 +181,6 @@ export default function DisplayImageUpload({
 }: Props) {
   const [loadError, setLoadError] = useState(false);
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const uppy = useUppy(() => {
-    const uppy = Uppy({
-      id: "uppy",
-      autoProceed: false,
-      allowMultipleUploads: false,
-      restrictions: {
-        maxNumberOfFiles: 1,
-        maxFileSize: 3145728, // 3 MB
-        /* Even this doesn't verify file content
-        e.g. when you rename a .json to .png and try to upload it */
-        allowedFileTypes: ["image/jpg", "image/jpeg", "image/png"],
-      },
-      infoTimeout: 5000,
-      locale: {
-        strings: {},
-      },
-    });
-
-    uppy.setOptions({
-      locale: {
-        strings: {
-          cancel: "Cancel",
-          done: "Cancel",
-        },
-      },
-    });
-
-    uppy.use(ImageEditor, {
-      id: "ImageEditor",
-      quality: 0.3,
-      cropperOptions: {
-        viewMode: 1,
-        aspectRatio: 1,
-        background: false,
-        responsive: true,
-        autoCropArea: 0.8,
-        autoCrop: true,
-      },
-      actions: {
-        revert: false,
-        rotate: false,
-        flip: false,
-        zoomIn: false,
-        zoomOut: false,
-        cropSquare: false,
-        cropWidescreen: false,
-        cropWidescreenVertical: false,
-      },
-    });
-
-    uppy.on("file-added", (file: File) => {
-      isFileContentAnImageType(file)
-        .then(() => {
-          onChange(file);
-          // TO trigger edit modal
-          const dashboard = uppy.getPlugin("uppy-img-upload-dashboard");
-          setTimeout(() => {
-            (dashboard as any).openFileEditor(file);
-          });
-        })
-        .catch(() => {
-          uppy.removeFile(uppy.getFiles()[0].id);
-          onInvalidFileContent?.();
-        });
-    });
-
-    uppy.on("upload", () => {
-      submit(uppy);
-      setIsModalOpen(false);
-    });
-
-    uppy.on("file-editor:complete", (updatedFile) => {
-      onChange(updatedFile);
-    });
-
-    return uppy;
-  });
 
   useEffect(() => {
     if (value) setLoadError(false);
@@ -302,50 +228,22 @@ export default function DisplayImageUpload({
           </div>
         }
       >
-        <Dashboard
-          id="uppy-img-upload-dashboard"
-          note="File size must not exceed 3 MB"
-          plugins={["ImageEditor"]}
-          uppy={uppy}
-          disableInformer={disableUppyInformer}
-        />
+        <Suspense
+          fallback={
+            <SpinnerContainer>
+              <Spinner size={IconSize.XXXXL} />
+            </SpinnerContainer>
+          }
+        >
+          <DashboardLazy
+            onChange={onChange}
+            onInvalidFileContent={onInvalidFileContent}
+            submit={submit}
+            disableUppyInformer={disableUppyInformer}
+            onModalCloseRequested={() => setIsModalOpen(false)}
+          />
+        </Suspense>
       </StyledDialog>
     </Container>
   );
 }
-
-const isFileContentAnImageType = (file: File) => {
-  // ref: https://stackoverflow.com/questions/18299806/how-to-check-file-mime-type-with-javascript-before-upload
-  return new Promise((resolve, reject) => {
-    // get first 4 bytes of the file
-    const blob = (file as any).data.slice(0, 4);
-    const reader = new FileReader();
-    reader.onloadend = () => {
-      if (reader.result) {
-        // convert content to a unsigned int array to read it's value
-        // then toString(16) converts to hexadecimal
-        const initialBytesOfFile = new Uint8Array(reader.result as ArrayBufferLike)
-                                .reduce((prev, curr ) => prev + curr.toString(16), "");
-        /*
-          compare initialBytesOfFile with magic numbers to identify file signature
-          file signatures reference: https://en.wikipedia.org/wiki/List_of_file_signatures
-        */
-        switch (initialBytesOfFile) {
-          // image/png
-          case "89504e47":
-            resolve(true);
-            break;
-          // image/jpeg or image/jpg
-          case "ffd8ffe0":
-          case "ffd8ffe1":
-          case "ffd8ffdb":
-          case "ffd8ffee":
-            resolve(true);
-            break;
-        }
-        reject();
-      }
-    };
-    reader.readAsArrayBuffer(blob);
-  });
-};

--- a/packages/design-system-old/src/DisplayImageUpload/index.tsx
+++ b/packages/design-system-old/src/DisplayImageUpload/index.tsx
@@ -11,8 +11,7 @@ import {
 import { getTypographyByKey } from "Constants/typography";
 
 import { ReactComponent as ProfileImagePlaceholder } from "../assets/icons/others/profile-placeholder.svg";
-import Spinner from "Spinner";
-import { IconSize } from "Icon";
+import Icon, { IconSize } from "Icon";
 
 type Props = {
   onChange: (file: File) => void;
@@ -175,7 +174,10 @@ const SpinnerContainer = styled.div`
 `;
 
 // Dashboard is code-split away to avoid bundling Uppy in the main bundle
-const DashboardLazy = React.lazy(() => import("./Dashboard"));
+const DashboardLazy = React.lazy(async () => {
+  await new Promise((resolve) => setTimeout(resolve, 10000));
+  return import("./Dashboard");
+});
 
 export default function DisplayImageUpload({
   onChange,
@@ -237,7 +239,7 @@ export default function DisplayImageUpload({
         <Suspense
           fallback={
             <SpinnerContainer>
-              <Spinner size={IconSize.XXXXL} />
+              <Icon name={"loader"} size={IconSize.XL} />
             </SpinnerContainer>
           }
         >

--- a/packages/design-system-old/src/DisplayImageUpload/index.tsx
+++ b/packages/design-system-old/src/DisplayImageUpload/index.tsx
@@ -169,6 +169,7 @@ const SpinnerContainer = styled.div`
   justify-content: center;
 `;
 
+// Dashboard is code-split away to avoid bundling Uppy in the main bundle
 const DashboardLazy = React.lazy(() => import("./Dashboard"));
 
 export default function DisplayImageUpload({


### PR DESCRIPTION
## Description

This PR code-splits the `DisplayImageUpload` dashboard to make and [Uppy](https://uppy.io/) load on demand. Together with https://github.com/appsmithorg/appsmith/pull/24969, this shaves ~200 minified kBs off the bundle size.

While the dashboard is loading, we now render the spinner component:

<img width="1624" alt="CleanShot 2023-06-30 at 10 37 37@2x" src="https://github.com/appsmithorg/design-system/assets/2953267/b41b9b90-eccb-4bfe-b8ec-fc1c78577045">

## Type of change

- Chore (housekeeping or task changes that don't impact user perception)

## How Has This Been Tested?

- Manual on storybook

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
