### PR TITLE
chore: Adding user settings line icon from remixicon react

### DIFF
--- a/.changeset/fifty-planets-repeat.md
+++ b/.changeset/fifty-planets-repeat.md
@@ -1,0 +1,5 @@
+---
+"@appsmithorg/design-system": patch
+---
+
+chore: Adding user settings line icon from remixicon react

--- a/packages/design-system/src/Icon/Icon.provider.tsx
+++ b/packages/design-system/src/Icon/Icon.provider.tsx
@@ -375,6 +375,9 @@ const UserAddLineIcon = importRemixIcon(
 const UserUnfollowLineIcon = importRemixIcon(
   () => import("remixicon-react/UserUnfollowLineIcon"),
 );
+const UserSettingsLineIcon = importRemixIcon(
+  () => import("remixicon-react/UserSettingsLineIcon"),
+);
 const DeleteRowIcon = importRemixIcon(
   () => import("remixicon-react/DeleteRowIcon"),
 );
@@ -1110,6 +1113,7 @@ const ICON_LOOKUP = {
   "user-follow-line": UserFollowLineIcon,
   "user-heart-line": UserHeartLineIcon,
   "user-received-2-line": UserReceived2LineIcon,
+  "user-settings-line": UserSettingsLineIcon,
   "user-shared-line": UserSharedLineIcon,
   "user-unfollow-line": UserUnfollowLineIcon,
   "view-all": RightArrowIcon,


### PR DESCRIPTION
## Description

Adding user settings line icon from remixicon react

Fixes [#25270](https://github.com/appsmithorg/appsmith/issues/25270)

Depends on [#25404](https://github.com/appsmithorg/appsmith/pull/25404)

## Type of change
- Chore (housekeeping or task changes that don't impact user perception)

## How Has This Been Tested?
- Manual on storybook 

## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
