### PR TITLE
docs: separate resources from references

### DIFF
--- a/.changeset/rude-cooks-tease.md
+++ b/.changeset/rude-cooks-tease.md
@@ -1,0 +1,5 @@
+---
+"@appsmithorg/design-system": patch
+---
+
+docs: separate resources from references

--- a/packages/design-system/src/Button/Button.mdx
+++ b/packages/design-system/src/Button/Button.mdx
@@ -97,9 +97,13 @@ All parameters that are available to buttons are available to Iconbuttons.
 - Icon buttons are typically not grouped with regular buttons.
 
 ---
-### References
+## Resources
+1. Our button component accepts all arguments [HTML's button tag](https://developer.mozilla.org/en-US/docs/Web/API/HTMLButtonElement) accepts.
+
+## References
 1. https://makeitclear.com/ux-ui-tips-a-guide-to-creating-buttons/
-2. https://developer.mozilla.org/en-US/docs/Web/API/HTMLButtonElement
+2. https://marcysutton.com/links-vs-buttons-in-modern-web-applications
+
 
 
 

--- a/packages/design-system/src/DesignTokens.mdx
+++ b/packages/design-system/src/DesignTokens.mdx
@@ -77,7 +77,7 @@ Every UI element comprises of structural surfaces that are styled using presenta
 [//]: # (TODO: Get labelled screenshot from Vasanth- https://www.notion.so/appsmith/How-to-style-using-design-tokens-fcc35bf74ce14083962704be5b3939cd?pvs=4#3c74a11be196461982175e8ed823fe55)
 ![Parts of an input](./docs/labelled-input.png)
 
-Structural elements do not always comprise of text.
+Structural elements do not always comprise text.
 
 ![Parts of a switch](./docs/parts-of-a-switch.png)
 <figcaption>The knob and track are structural elements of a Switch that lend it a distinctive look.</figcaption>

--- a/packages/design-system/src/Input/Input.mdx
+++ b/packages/design-system/src/Input/Input.mdx
@@ -52,7 +52,8 @@ The [number input](https://design-system.appsmith.com/?path=/docs/design-system-
 
 ### Sizing
 
-## Reference
 
-1. https://react-spectrum.adobe.com/react-aria/useTextField.html
-2. https://react-spectrum.adobe.com/react-aria/TextField.html
+---
+## Resources
+1. Internally, our input component uses [React Aria's useTextField hook](https://react-spectrum.adobe.com/react-aria/useTextField.html)
+2. It accepts all the props specified in [React Aria's TextField](https://react-spectrum.adobe.com/react-aria/TextField.html)

--- a/packages/design-system/src/Link/Link.mdx
+++ b/packages/design-system/src/Link/Link.mdx
@@ -40,3 +40,10 @@ To enhance usability, ensure that link text is meaningful even when viewed out o
 ### Colour
 
 Links should be visually consistent with the surrounding text by adopting the default primary color. Links inher
+
+---
+## Resources
+1. Internally, our link component uses [React Aria's useLink hook](https://react-spectrum.adobe.com/react-aria/useLink.html).
+
+## References
+1. https://marcysutton.com/links-vs-buttons-in-modern-web-applications

--- a/packages/design-system/src/Modal/Modal.mdx
+++ b/packages/design-system/src/Modal/Modal.mdx
@@ -42,6 +42,6 @@ To do this, use a primary button on the right to indicate if the user should pro
 
 <Canvas of={ModalStories.ModalStoryTwo} />
 
-## References
-
-1. https://www.radix-ui.com/docs/primitives/components/dialog
+---
+## Resources
+1. Internally, our modal component depends on [radix's dialog](https://www.radix-ui.com/docs/primitives/components/dialog)

--- a/packages/design-system/src/Select/Select.mdx
+++ b/packages/design-system/src/Select/Select.mdx
@@ -65,6 +65,6 @@ The select component should:
 
 - Avoid using a select component if there are fewer than three options for selection. Instead, use a radio button group.
 
-## Reference
-
-1. https://select-react-component.vercel.app/
+---
+## Resources
+1. Internally, our select component is a wrapper around [rc-select](https://select-react-component.vercel.app/)

--- a/packages/design-system/src/Toast/Toast.mdx
+++ b/packages/design-system/src/Toast/Toast.mdx
@@ -51,5 +51,6 @@ When to use:
 - For success messages
 - Only for non-critical errors that are relevant at the moment and can be explained in a few words.
 
-## Reference
+---
+## Resources
 1. Internally, toast uses [react-toastify](https://fkhadra.github.io/react-toastify/introduction/)


### PR DESCRIPTION
## Description

This PR makes a distinction between further reading for developers and references used while creating the documentation

Fixes # (issue)

Depends on # (pr)

## Type of change

- Chore (housekeeping or task changes that don't impact user perception)

## How Has This Been Tested?

- Manual on storybook 
- Manual on main repo
- Jest
- Cypress

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
