### PR TITLE
ci: Added generate alpha command workflow

### DIFF
--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -1,11 +1,10 @@
 name: NPM Alpha Publish Release Workflow
 
 on:
-  pull_request:
-    branches: [release]
-    types: [opened, reopened, edited]
-    paths:
-      - "packages/**"
+  # This workflow is only triggered by the ok to test command dispatch
+  workflow_call:
+  repository_dispatch:
+    types: [generate-alpha-command]
     
 jobs:
   release:
@@ -73,7 +72,7 @@ jobs:
 
       - name: Comment version details in PR
         if: steps.changesets.outputs.published == 'true'
-        uses: peter-evans/create-or-update-comment@v1
+        uses: peter-evans/create-or-update-comment@v2
         with:
           issue-number: ${{ github.event.client_payload.pull_request.number }}
           body: |

--- a/.github/workflows/generate-alpha.yml
+++ b/.github/workflows/generate-alpha.yml
@@ -1,0 +1,32 @@
+# If someone with write access comments "/generate-alpha" on a pull request, emit a repository_dispatch event
+name: Generate Alpha
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  generate-alpha:
+    runs-on: ubuntu-latest
+    # Only run for PRs, not issue comments
+    if: |
+      github.event.issue.pull_request
+    steps:
+      - name: Generate token
+        id: generate_token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.APPSMITH_INTEGRATION_TESTING_ID }}
+          private_key: ${{ secrets.APPSMITH_INTEGRATION_TESTING_KEY }}
+
+      - name: Slash Command Dispatch
+        uses: peter-evans/slash-command-dispatch@v3
+        env:
+          TOKEN: ${{ steps.generate_token.outputs.token }}
+        with:
+          token: ${{ env.TOKEN }} # GitHub App installation access token
+          reaction-token: ${{ secrets.GITHUB_TOKEN }}
+          issue-type: pull-request
+          commands: |
+            generate-alpha
+          permission: write


### PR DESCRIPTION
## Description

Added workflow to generate alpha version from slash command.
`/generate-alpha`


Fixes #

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Manual on storybook 
- Manual on main repo
- Jest
- Cypress

### Test Plan

### Issues raised during DP testing


## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
