### PR TITLE
fix: change collapsible toggle arrow directions from up/down to down/right

### DIFF
--- a/.changeset/stale-drinks-hide.md
+++ b/.changeset/stale-drinks-hide.md
@@ -1,0 +1,5 @@
+---
+"@appsmithorg/design-system": patch
+---
+
+fix: change collapsible toggle arrow directions from up/down to down/right

--- a/packages/design-system/src/Collapsible/Collapsible.tsx
+++ b/packages/design-system/src/Collapsible/Collapsible.tsx
@@ -39,7 +39,7 @@ function CollapsibleHeader(props: CollapsibleHeaderProps) {
     >
       {arrowPosition === ARROW_POSITIONS.START && (
         <Icon
-          name={isExpanded ? "arrow-up-s-line" : "arrow-down-s-line"}
+          name={isExpanded ? "arrow-down-s-line" : "arrow-right-s-line"}
           size="md"
         />
       )}
@@ -48,7 +48,7 @@ function CollapsibleHeader(props: CollapsibleHeaderProps) {
 
       {arrowPosition === ARROW_POSITIONS.END && (
         <StyledEndIcon
-          name={isExpanded ? "arrow-up-s-line" : "arrow-down-s-line"}
+          name={isExpanded ? "arrow-down-s-line" : "arrow-right-s-line"}
           size="md"
         />
       )}


### PR DESCRIPTION
## Description
Pretty simple, we are changing the toggle arrow directions of the collapsible widget from up/down to down/right to match other collapsible on the entity explorer such as widgets/pages/datasources etc.

Fixes #587

Depends on # (pr)
> every PR in the design-system repository should have a corresponding PR in the appsmith repository to ensure that changes 
> here don't break existing flows. Link the corresponding PR here to trigger dpulls and prevent accidental merging.
> If relevant, link the enterprise PR here as well.

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manual on storybook 
- Manual on main repo
- Jest
- Cypress

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
