### PR TITLE
fix: divider spacing

### DIFF
--- a/.changeset/thirty-plants-brush.md
+++ b/.changeset/thirty-plants-brush.md
@@ -1,0 +1,5 @@
+---
+"@appsmithorg/design-system": patch
+---
+
+fix: divider spacing

--- a/packages/design-system/src/Divider/Divider.styles.tsx
+++ b/packages/design-system/src/Divider/Divider.styles.tsx
@@ -15,5 +15,5 @@ export const StyledDivider = styled.span<{
       ? "border-top: var(--divider-thickness) solid var(--ads-v2-colors-content-surface-default-border); width: var(--divider-length);"
       : "border-left: var(--divider-thickness) solid var(--ads-v2-colors-content-surface-default-border); height: var(--divider-length);"}
 
-  display: inline-block;
+  display: block;
 `;


### PR DESCRIPTION
## Description

Fixes https://github.com/appsmithorg/appsmith/issues/26815

This PR changes divider's display type from `inline-block` to `block`. When an element is `inline-block`, it inherits a line height from the body which shows up as spacing that is unaccounted for. Changing the element to `block` fixes this. 

https://theappsmith.slack.com/archives/C0293DVQACW/p1693246318677089?thread_ts=1693195050.352919&cid=C0293DVQACW

These are the usages of divider: https://feta.omlet.dev/appsmith/components/Divider%3A%3Adesign-system%3Ae3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855%3ADivider?type=parents

![Screenshot 2023-08-29 at 7 52 22 AM](https://github.com/appsmithorg/design-system/assets/13763558/70b9c651-4124-4ef1-a68b-501a367894a4)

Depends on https://github.com/appsmithorg/appsmith/pull/26728

In the course of working on this fix, a bug was noticed, and fixed below. 
Depends on https://github.com/appsmithorg/design-system/pull/603

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Manual on storybook 
- Manual on main repo
- Jest
- Cypress

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
