### PR TITLE
fix: divider colors

### DIFF
--- a/.changeset/moody-fans-warn.md
+++ b/.changeset/moody-fans-warn.md
@@ -1,0 +1,5 @@
+---
+"@appsmithorg/design-system": patch
+---
+
+fix: divider colors

--- a/packages/design-system/src/DatePicker/styles.css
+++ b/packages/design-system/src/DatePicker/styles.css
@@ -5,7 +5,7 @@
 /* This follows the popover styles, hence the category content */
 .react-datepicker.ads-v2-datepicker__calender {
   background-color: var(--ads-v2-colors-content-surface-default-bg);
-  border: 1px solid var(--ads-v2-colors-content-surface-default-border);
+  border: 1px solid var(--ads-v2-colors-content-container-default-border);
   border-radius: var(--ads-v2-border-radius);
   box-shadow: var(--ads-v2-shadow-popovers);
   padding: var(--ads-v2-spaces-3);
@@ -63,7 +63,7 @@
   padding-right: var(--ads-v2-spaces-3);
   margin-left: -8px;
   margin-right: -32px;
-  border-left: 1px solid var(--ads-v2-colors-content-surface-default-border);
+  border-left: 1px solid var(--ads-v2-colors-content-container-default-border);
 }
 
 /* Custom header wrapper */

--- a/packages/design-system/src/Menu/Menu.styles.tsx
+++ b/packages/design-system/src/Menu/Menu.styles.tsx
@@ -38,7 +38,7 @@ const MenuContentStyle = css`
   max-height: calc(var(--radix-dropdown-menu-content-available-height) - 20px);
   background-color: var(--ads-v2-colors-content-surface-default-bg);
   border-radius: var(--ads-v2-border-radius);
-  border: 1px solid var(--ads-v2-colors-content-surface-default-border);
+  border: 1px solid var(--ads-v2-colors-content-container-default-border);
   box-shadow: var(--ads-v2-shadow-popovers);
   padding: var(--ads-v2-spaces-2);
   animation-duration: 400ms;

--- a/packages/design-system/src/Popover/Popover.styles.tsx
+++ b/packages/design-system/src/Popover/Popover.styles.tsx
@@ -31,7 +31,7 @@ export const StyledContent = styled(Content)<{ $size: PopoverSize }>`
   padding: var(--popover-padding);
 
   background-color: var(--ads-v2-colors-content-surface-default-bg);
-  border: 1px solid var(--ads-v2-colors-content-surface-default-border);
+  border: 1px solid var(--ads-v2-colors-content-container-default-border);
   border-radius: var(--ads-v2-border-radius);
   box-shadow: var(--ads-v2-shadow-popovers);
 

--- a/packages/design-system/src/Select/styles.css
+++ b/packages/design-system/src/Select/styles.css
@@ -183,7 +183,7 @@
   min-height: unset;
   background-color: var(--ads-v2-colors-content-surface-default-bg);
   border-radius: var(--ads-v2-border-radius);
-  border: 1px solid var(--ads-v2-colors-content-surface-default-border);
+  border: 1px solid var(--ads-v2-colors-content-container-default-border);
   box-shadow: var(--ads-v2-shadow-popovers);
   padding: var(--ads-v2-spaces-2);
   animation-duration: 400ms;

--- a/packages/design-system/src/__theme__/default/index.css
+++ b/packages/design-system/src/__theme__/default/index.css
@@ -130,13 +130,16 @@
   --ads-v2-colors-content-surface-warning-bg: var(--ads-v2-color-bg-warning);
   --ads-v2-colors-content-surface-special-bg: var(--ads-v2-color-bg-special);
   --ads-v2-colors-content-surface-premium-bg: var(--ads-v2-color-bg-premium);
-  --ads-v2-colors-content-surface-default-border: var(--ads-v2-color-border-muted);
+  --ads-v2-colors-content-surface-default-border: var(--ads-v2-color-border);
   --ads-v2-colors-content-surface-info-border: var(--ads-v2-color-border-info);
   --ads-v2-colors-content-surface-success-border: var(--ads-v2-color-border-success);
   --ads-v2-colors-content-surface-error-border: var(--ads-v2-color-border-error);
   --ads-v2-colors-content-surface-warning-border: var(--ads-v2-color-border-warning);
   --ads-v2-colors-content-surface-special-border: var(--ads-v2-color-border-special);
   --ads-v2-colors-content-surface-premium-border: var(--ads-v2-color-border-premium);
+
+  --ads-v2-colors-content-container-default-border: var(--ads-v2-color-border-muted);
+
 
   /**
     * ===========================================*


### PR DESCRIPTION
## Description

When the [category token was changed for popover border](https://github.com/appsmithorg/design-system/pull/590/commits/0e7994a6cbed276614dcea8f0a576b39092b829a), the divider color was also changed from default-border to default border muted. However, this dependency didn't show up in my editor as a "usage" because the token is used inside a string. Since this change was unintentional and won't work for our platform, this PR creates two tokens for content-border, one for surface (which divider and menu divider uses), and one for container (which menu, select, popover, and date picker uses). 

Depends on # (pr)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Manual on storybook 
- Manual on main repo
- Jest
- Cypress

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
