### PR TITLE
fix: Updating tag input value to original value, when the form is reset

### DIFF
--- a/.changeset/angry-news-care.md
+++ b/.changeset/angry-news-care.md
@@ -1,0 +1,6 @@
+---
+"@appsmithorg/design-system-old": patch
+"@appsmithorg/design-system": patch
+---
+
+fix: Updating the value of tag input to the original value, when the form is reset

--- a/packages/design-system-old/src/TagInput/index.tsx
+++ b/packages/design-system-old/src/TagInput/index.tsx
@@ -129,7 +129,11 @@ function TagInputComponent(props: TagInputProps) {
     if (inputValues.length > 0 && values.length === 0) {
       setValues(inputValues);
     }
-  }, [inputValues, values]);
+
+    if (props.input.value !== values.join(",")) {
+      setValues(inputValues);
+    }
+  }, [inputValues, values, props.input.value]);
 
   const validateEmail = (newValues: string[]) => {
     if (newValues && newValues.length > 0) {

--- a/packages/design-system-old/src/TagInput/index.tsx
+++ b/packages/design-system-old/src/TagInput/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useMemo } from "react";
 import styled from "styled-components";
 import { Classes, TagInput } from "@blueprintjs/core";
 import {
@@ -112,10 +112,13 @@ type TagInputProps = {
  * @param props : TagInputProps
  */
 function TagInputComponent(props: TagInputProps) {
-  const inputValues =
-    props.input.value && props.input.value.length > 0
-      ? props.input.value.split(",")
-      : [];
+  const inputValues = useMemo(
+    () =>
+      props.input.value && props.input.value.length > 0
+        ? props.input.value.split(",")
+        : [],
+    [props.input.value],
+  );
   const [values, setValues] = useState<string[]>(inputValues || []);
   const [currentValue, setCurrentValue] = useState<string>("");
 


### PR DESCRIPTION
## Description

Updating tag input value to original value, when the form is reset

Fixes [#27671](https://github.com/appsmithorg/appsmith/issues/27671)

Depends on [#27681](https://github.com/appsmithorg/appsmith/pull/27681) [#2485](https://github.com/appsmithorg/appsmith-ee/pull/2485)

## Type of change
- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
- Manual on storybook 
- Manual on main repo

## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
