### PR TITLE
fix: rc select ui broken after css module update

### DIFF
--- a/packages/design-system/rollup.config.mjs
+++ b/packages/design-system/rollup.config.mjs
@@ -27,7 +27,6 @@ export default {
       useTsconfigDeclarationDir: true,
     }),
     postcss({
-      modules: true,
       minimize: true,
       sourceMap: true,
       plugins: [postcssImport()],

--- a/packages/design-system/src/custom.d.ts
+++ b/packages/design-system/src/custom.d.ts
@@ -9,9 +9,3 @@ declare module "*.png" {
   const value: any;
   export default value;
 }
-
-// declaration.d.ts
-declare module "*.css" {
-  const content: Record<string, string>;
-  export default content;
-}


### PR DESCRIPTION
## Description

After making postcss changes for css module, rc select classes was also getting appended with unique id. This caused the issue of breaking select component UI.

Fixes #https://github.com/appsmithorg/appsmith/issues/27988


## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manual on storybook 
- Manual on main repo
- Jest
- Cypress

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
