### PR TITLE
feat: allow react node for start icon in ListItem

### DIFF
--- a/.changeset/perfect-mice-refuse.md
+++ b/.changeset/perfect-mice-refuse.md
@@ -1,0 +1,5 @@
+---
+"@appsmithorg/design-system": patch
+---
+
+feat: allow react node for start icon in ListItem

--- a/packages/design-system/src/List/List.stories.tsx
+++ b/packages/design-system/src/List/List.stories.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import { List, ListItem } from "./List";
+import { Icon } from "../Icon";
 
 export default {
   title: "Design System/List",
@@ -30,31 +31,31 @@ ListStory.storyName = "List";
 ListStory.args = {
   items: [
     {
-      startIcon: "box-3-line",
+      startIcon: <Icon name="file-list-2-line" size={"md"} />,
       title: "Action item 1",
     },
     {
-      startIcon: "box-3-line",
+      startIcon: <Icon name="file-list-2-line" size={"md"} />,
       title: "Action item 2",
     },
     {
-      startIcon: "box-3-line",
+      startIcon: <Icon name="file-list-2-line" size={"md"} />,
       title: "Action item 3",
     },
     {
-      startIcon: "box-3-line",
+      startIcon: <Icon name="file-list-2-line" size={"md"} />,
       title: "Action item 4",
     },
     {
-      startIcon: "box-3-line",
+      startIcon: <Icon name="file-list-2-line" size={"md"} />,
       title: "Action item 5",
     },
     {
-      startIcon: "box-3-line",
+      startIcon: <Icon name="file-list-2-line" size={"md"} />,
       title: "Action item 6",
     },
     {
-      startIcon: "box-3-line",
+      startIcon: <Icon name="file-list-2-line" size={"md"} />,
       title: "Action item 7",
     },
   ],
@@ -71,11 +72,10 @@ const ListItemArgTypes = {
     },
   },
   startIcon: {
-    control: "text",
     description: "The icon to display before the list item title.",
     table: {
       type: {
-        summary: "string",
+        summary: "ReactNode",
       },
     },
   },
@@ -157,7 +157,7 @@ export const ListItemLargeStory = ListItemTemplate.bind({});
 ListItemLargeStory.storyName = "List item size large";
 ListItemLargeStory.argTypes = ListItemArgTypes;
 ListItemLargeStory.args = {
-  startIcon: "box-3-line",
+  startIcon: <Icon name="file-list-2-line" size={"md"} />,
   title: "Action item 1",
   description: "inline",
   descriptionType: "inline",
@@ -169,7 +169,13 @@ export const ListItemErrorStory = ListItemTemplate.bind({});
 ListItemErrorStory.storyName = "List item with error";
 ListItemErrorStory.argTypes = ListItemArgTypes;
 ListItemErrorStory.args = {
-  startIcon: "box-3-line",
+  startIcon: (
+    <Icon
+      color="var(--ads-v2-color-fg-error)"
+      name="file-list-2-line"
+      size={"md"}
+    />
+  ),
   title: "Action item 1",
   hasError: true,
   onClick: () => alert("Clicked"),

--- a/packages/design-system/src/List/List.styles.tsx
+++ b/packages/design-system/src/List/List.styles.tsx
@@ -31,6 +31,9 @@ export const StyledList = styled.div`
   height: 100%;
   overflow: auto;
   padding: var(--ads-v2-spaces-1);
+  display: flex;
+  flex-direction: column;
+  gap: var(--ads-v2-spaces-2);
 `;
 
 export const Wrapper = styled.div`
@@ -41,10 +44,6 @@ export const Wrapper = styled.div`
   cursor: pointer;
   box-sizing: border-box;
   position: relative;
-`;
-
-export const StartIconWrapper = styled.div`
-  align-self: flex-start;
 `;
 
 export const TooltipTextWrapper = styled.div`
@@ -103,14 +102,6 @@ export const StyledListItem = styled.div<{
 
   ${({ size }) => Sizes[size]}
 
-  ${({ isBlockDescription, size }) =>
-    size === "lg" &&
-    isBlockDescription &&
-    `
-    ${DescriptionWrapper} {
-      padding-top: var(--ads-v2-spaces-1);
-    }
-  `}
 
   & .${ListItemTextOverflowClassName} {
     overflow: hidden;

--- a/packages/design-system/src/List/List.tsx
+++ b/packages/design-system/src/List/List.tsx
@@ -7,13 +7,11 @@ import {
   DescriptionWrapper,
   EndIconWrapper,
   InlineDescriptionWrapper,
-  StartIconWrapper,
   StyledList,
   StyledListItem,
   TooltipTextWrapper,
   Wrapper,
 } from "./List.styles";
-import { Icon } from "Icon";
 import { Text, TextProps } from "Text";
 import { Button } from "Button";
 import { Tooltip } from "Tooltip";
@@ -140,15 +138,7 @@ function ListItem(props: ListItemProps) {
         tabIndex={props.isDisabled ? -1 : 0}
       >
         <ContentTextWrapper>
-          <StartIconWrapper>
-            {startIcon && (
-              <Icon
-                color={hasError ? "var(--ads-v2-color-fg-error)" : undefined}
-                name={startIcon}
-                size={size}
-              />
-            )}
-          </StartIconWrapper>
+          {startIcon}
           <InlineDescriptionWrapper>
             <DescriptionWrapper>
               <TextWithTooltip

--- a/packages/design-system/src/List/List.types.tsx
+++ b/packages/design-system/src/List/List.types.tsx
@@ -1,10 +1,11 @@
 import { Sizes } from "__config__/types";
+import { ReactNode } from "react";
 
 export type ListSizes = Extract<Sizes, "md" | "lg">;
 
 export type ListItemProps = {
-  /** The icon to display before the list item title. Pass name of the icon from remix-icon library(eg: home-2-line) or an svg icon. */
-  startIcon?: string;
+  /** The icon to display before the list item title. */
+  startIcon?: ReactNode;
   /** The icon to display at the end. Pass name of the icon from remix-icon library(eg: home-2-line) or an svg icon. */
   endIcon?: string;
   /** callback for when the endIcon is clicked */


### PR DESCRIPTION
## Description

Fixes https://github.com/appsmithorg/appsmith/issues/28212

## Type of change

- New feature (non-breaking change which adds functionality)


## How Has This Been Tested?

- [x] Manual on storybook 
- [ ] Manual on main repo


### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
