### PR TITLE
fix: Added z-index for table head

### DIFF
--- a/.changeset/fluffy-badgers-love.md
+++ b/.changeset/fluffy-badgers-love.md
@@ -1,0 +1,5 @@
+---
+"@appsmithorg/design-system-old": patch
+---
+
+fix: Added z-index for table head

--- a/packages/design-system-old/src/Table/index.tsx
+++ b/packages/design-system-old/src/Table/index.tsx
@@ -20,6 +20,7 @@ const Styles = styled.div`
     thead {
       position: sticky;
       top: 0;
+      z-index: 1;
 
       tr {
         background-color: var(--ads-v2-color-bg-subtle);


### PR DESCRIPTION
## Description

Added z-index to sticky thead to avoid row components overlapping.

Fixes https://github.com/appsmithorg/appsmith/issues/28014

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Manual on storybook 
- Manual on main repo
- Jest
- Cypress

## Checklist:
### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
