### PR TITLE
fix: List component line height class name

### DIFF
--- a/.changeset/dull-donkeys-play.md
+++ b/.changeset/dull-donkeys-play.md
@@ -1,0 +1,5 @@
+---
+"@appsmithorg/design-system": patch
+---
+
+fix: List component line height class name

--- a/.changeset/fluffy-badgers-love.md
+++ b/.changeset/fluffy-badgers-love.md
@@ -1,5 +1,0 @@
----
-"@appsmithorg/design-system-old": patch
----
-
-fix: Added z-index for table head

--- a/.changeset/perfect-mice-refuse.md
+++ b/.changeset/perfect-mice-refuse.md
@@ -1,5 +1,0 @@
----
-"@appsmithorg/design-system": patch
----
-
-feat: allow react node for start icon in ListItem

--- a/.changeset/stale-parrots-learn.md
+++ b/.changeset/stale-parrots-learn.md
@@ -1,5 +1,0 @@
----
-"@appsmithorg/design-system": patch
----
-
-feat: Added form control

--- a/packages/design-system-old/CHANGELOG.md
+++ b/packages/design-system-old/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @appsmithorg/design-system
 
+## 1.1.13
+
+### Patch Changes
+
+- [#660](https://github.com/appsmithorg/design-system/pull/660) [`e455013f`](https://github.com/appsmithorg/design-system/commit/e455013ff31f941e2de126bba0d6d84c06a73722) Thanks [@albinAppsmith](https://github.com/albinAppsmith)! - fix: Added z-index for table head
+
 ## 1.1.12
 
 ### Patch Changes

--- a/packages/design-system-old/package.json
+++ b/packages/design-system-old/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@appsmithorg/design-system-old",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "description": "This is the package for the Appsmith design system components",
   "module": "build/index.js",
   "types": "build/index.d.ts",

--- a/packages/design-system/CHANGELOG.md
+++ b/packages/design-system/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @appsmithorg/design-system
 
+## 2.1.25
+
+### Patch Changes
+
+- [#657](https://github.com/appsmithorg/design-system/pull/657) [`46ff5a31`](https://github.com/appsmithorg/design-system/commit/46ff5a31f91e322c5d1d64782943c0e8cb2eb0c1) Thanks [@akash-codemonk](https://github.com/akash-codemonk)! - feat: allow react node for start icon in ListItem
+
+- [#654](https://github.com/appsmithorg/design-system/pull/654) [`a5d82e3b`](https://github.com/appsmithorg/design-system/commit/a5d82e3b57ba602d49ada69ed9edaf0f6cb0b6a7) Thanks [@albinAppsmith](https://github.com/albinAppsmith)! - feat: Added form control
+
 ## 2.1.24
 
 ### Patch Changes

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@appsmithorg/design-system",
-  "version": "2.1.24",
+  "version": "2.1.25",
   "description": "This is the package for the design system that powers the Appsmith platform",
   "module": "build/index.js",
   "types": "build/index.d.ts",

--- a/packages/design-system/src/List/List.constants.ts
+++ b/packages/design-system/src/List/List.constants.ts
@@ -3,6 +3,7 @@ import { CLASS_NAME_PREFIX } from "__config__/constants";
 export const ListClassName = `${CLASS_NAME_PREFIX}-list`;
 export const ListItemClassName = `${CLASS_NAME_PREFIX}-listitem`;
 export const ListItemTitleClassName = `${ListItemClassName}__title`;
+export const ListItemWrapperClassName = `${ListItemClassName}__wrapper`;
 export const ListItemIDescClassName = `${ListItemClassName}__idesc`;
 export const ListItemBDescClassName = `${ListItemClassName}__bdesc`;
 export const ListItemTextOverflowClassName = `${ListItemClassName}_text-overflow`;

--- a/packages/design-system/src/List/List.styles.tsx
+++ b/packages/design-system/src/List/List.styles.tsx
@@ -111,6 +111,7 @@ export const StyledListItem = styled.div<{
 
   & .${ListItemTitleClassName} {
     font-size: var(--listitem-title-font-size);
+    line-height: 16px;
   }
 
   & .${ListItemBDescClassName} {

--- a/packages/design-system/src/List/List.tsx
+++ b/packages/design-system/src/List/List.tsx
@@ -16,15 +16,18 @@ import { Text, TextProps } from "Text";
 import { Button } from "Button";
 import { Tooltip } from "Tooltip";
 import {
+  ListClassName,
   ListItemBDescClassName,
+  ListItemClassName,
   ListItemIDescClassName,
   ListItemTextOverflowClassName,
   ListItemTitleClassName,
+  ListItemWrapperClassName,
 } from "./List.constants";
 
-function List({ items }: ListProps) {
+function List({ className, items, ...rest }: ListProps) {
   return (
-    <StyledList>
+    <StyledList className={clsx(ListClassName, className)} {...rest}>
       {items.map((item) => {
         return <ListItem key={item.title} {...item} />;
       })}
@@ -126,8 +129,9 @@ function ListItem(props: ListItemProps) {
   };
 
   return (
-    <Wrapper>
+    <Wrapper className={clsx(ListItemWrapperClassName, props.wrapperClassName)}>
       <StyledListItem
+        className={clsx(ListItemClassName, props.className)}
         data-disabled={props.isDisabled || false}
         data-selected={props.isSelected}
         endIcon={props.endIcon}

--- a/packages/design-system/src/List/List.types.tsx
+++ b/packages/design-system/src/List/List.types.tsx
@@ -28,8 +28,16 @@ export type ListItemProps = {
    * below the title.
    */
   descriptionType: "inline" | "block";
+  /** class names for the list item */
+  className?: string;
+  /** class names for the wrapper */
+  wrapperClassName?: string;
+  /** id for the list item */
+  id?: string;
 };
 
 export type ListProps = {
   items: ListItemProps[];
+  className?: string;
+  id?: string;
 };


### PR DESCRIPTION
## Description

* Line height fix
* Added className support for List
* Added className & wrapperClassName support for ListItem

Fixes https://github.com/appsmithorg/appsmith/issues/28458

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Manual on storybook 
- Manual on main repo
- Jest
- Cypress

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
