### PR TITLE
feat: added copy button

### DIFF
--- a/packages/design-system/src/CopyButton/CopyButton.tsx
+++ b/packages/design-system/src/CopyButton/CopyButton.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import copySvg from '../__assets__/icons/ads/copy-svg.svg';
+import { border } from '@xstyled/styled-components';
+interface CopyButtonProps {
+  textToCopy: string;
+}
+
+const CopyButton: React.FC<CopyButtonProps> = ({ textToCopy }) => {
+  const handleCopyClick = () => {
+    const tempInput = document.createElement("input");
+    document.body.appendChild(tempInput);
+    tempInput.setAttribute("value", textToCopy);
+    tempInput.select();
+    document.execCommand("copy");
+    document.body.removeChild(tempInput);
+  };
+
+  return (
+    <button onClick={handleCopyClick} 
+    style={{border: "none"}}
+    >
+      <img
+      src={ copySvg } alt="Copy" />
+    </button>
+  );
+};
+
+export default CopyButton;

--- a/packages/design-system/src/Documentation/components/CodeBlock.tsx
+++ b/packages/design-system/src/Documentation/components/CodeBlock.tsx
@@ -2,12 +2,17 @@ import React from "react";
 import styled from "styled-components";
 import { Tooltip } from "Tooltip";
 import { toast } from "Toast";
+import CopyButton from "CopyButton/CopyButton";
+import { style } from "@xstyled/styled-components";
 
 type CodeBlockProps = {
   code?: string;
 };
 
 function CodeBlock({ code }: CodeBlockProps) {
+  if (code === undefined) {
+    return null;
+  }
   return (
     <Wrapper
       onClick={() => {
@@ -16,7 +21,13 @@ function CodeBlock({ code }: CodeBlockProps) {
       }}
     >
       <Tooltip content="Click here to copy" mouseEnterDelay={0.7}>
-        <Code>{code}</Code>
+        <div>
+          <Code>{code}
+          <CopyButton 
+          textToCopy={code} 
+          />
+          </Code>
+        </div>
       </Tooltip>
     </Wrapper>
   );
@@ -30,6 +41,7 @@ const Wrapper = styled.div`
   border-radius: var(--ads-v2-border-radius);
   background-color: var(--ads-v2-colors-content-surface-hover-bg);
   width: fit-content;
+  position: relative;
 `;
 
 const Code = styled.div`
@@ -37,5 +49,7 @@ const Code = styled.div`
   font-family: var(--ads-v2-font-family-code);
   white-space: pre-wrap;
 `;
+
+
 
 export { CodeBlock };

--- a/packages/design-system/src/__assets__/icons/ads/copy-svg.svg
+++ b/packages/design-system/src/__assets__/icons/ads/copy-svg.svg
@@ -1,0 +1,5 @@
+
+
+  <svg width="20px" height="20px" viewBox="0 0 24 24" fill="none" stroke="none" xmlns="http://www.w3.org/2000/svg">
+    <path fill-rule="evenodd" clip-rule="evenodd" d="M19.5 16.5L19.5 4.5L18.75 3.75H9L8.25 4.5L8.25 7.5L5.25 7.5L4.5 8.25V20.25L5.25 21H15L15.75 20.25V17.25H18.75L19.5 16.5ZM15.75 15.75L15.75 8.25L15 7.5L9.75 7.5V5.25L18 5.25V15.75H15.75ZM6 9L14.25 9L14.25 19.5L6 19.5L6 9Z" fill="#080341"/>
+  </svg>


### PR DESCRIPTION
## Description

> feat : Added a copy button on right of the tooltip
> added a copy svg image for it to accomplish 
> created a button component "CopyButton"


Fixes appsmithorg/appsmit#26847
> [Design System] - Show copy button in category token table instead of tooltip 

- New feature
- This change requires a new button component named "copyButton" to be added

## How Has This Been Tested?
> Manual

## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
