### PR TITLE
chore: Disable Icon clicks on NumberInput upon min-max violations

### DIFF
--- a/packages/design-system/src/Input/Input.constants.ts
+++ b/packages/design-system/src/Input/Input.constants.ts
@@ -7,3 +7,5 @@ export const InputSectionInputClassName = `${InputSectionClassName}-input`;
 export const InputIconClassName = `${InputSectionClassName}-icon`;
 export const InputStartIconClassName = `${InputIconClassName}-start`;
 export const InputEndIconClassName = `${InputIconClassName}-end`;
+export const InputStartIconDisabledClassName = `${InputStartIconClassName}-disabled`;
+export const InputEndIconDisabledClassName = `${InputEndIconClassName}-disabled`;

--- a/packages/design-system/src/Input/Input.styles.tsx
+++ b/packages/design-system/src/Input/Input.styles.tsx
@@ -1,8 +1,10 @@
 import styled, { css } from "styled-components";
 import {
   InputEndIconClassName,
+  InputEndIconDisabledClassName,
   InputIconClassName,
   InputStartIconClassName,
+  InputStartIconDisabledClassName,
 } from "./Input.constants";
 import { InputSizes } from "./Input.types";
 import { Text } from "Text";
@@ -117,6 +119,16 @@ export const InputContainer = styled.div<{
       cursor: not-allowed !important;
     }
   `};
+
+  & .${InputEndIconDisabledClassName} {
+    opacity: var(--ads-v2-opacity-disabled);
+    cursor: not-allowed !important;
+  }
+
+  & .${InputStartIconDisabledClassName} {
+    opacity: var(--ads-v2-opacity-disabled);
+    cursor: not-allowed !important;
+  }
 `;
 
 export const StyledInput = styled.input<{

--- a/packages/design-system/src/Input/Input.tsx
+++ b/packages/design-system/src/Input/Input.tsx
@@ -23,8 +23,6 @@ import {
   InputEndIconClassName,
   InputIconClassName,
   InputStartIconClassName,
-  InputStartIconDisabledClassName,
-  InputEndIconDisabledClassName,
 } from "./Input.constants";
 
 const Input = forwardRef<HTMLInputElement, InputProps>(
@@ -105,7 +103,6 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
                   InputIconClassName,
                   InputStartIconClassName,
                   startIconClassName,
-                  !startIconOnClick && InputStartIconDisabledClassName,
                 )}
                 data-has-onclick={!!startIconOnClick}
                 name={startIcon}
@@ -143,7 +140,6 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
                   InputIconClassName,
                   InputEndIconClassName,
                   endIconClassName,
-                  !endIconOnClick && InputEndIconDisabledClassName,
                 )}
                 data-has-onclick={!!endIconOnClick}
                 name={endIcon}

--- a/packages/design-system/src/Input/Input.tsx
+++ b/packages/design-system/src/Input/Input.tsx
@@ -23,6 +23,8 @@ import {
   InputEndIconClassName,
   InputIconClassName,
   InputStartIconClassName,
+  InputStartIconDisabledClassName,
+  InputEndIconDisabledClassName,
 } from "./Input.constants";
 
 const Input = forwardRef<HTMLInputElement, InputProps>(
@@ -31,6 +33,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
     const {
       className,
       description,
+      disableTextInput = false,
       endIcon,
       endIconProps,
       errorMessage,
@@ -102,6 +105,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
                   InputIconClassName,
                   InputStartIconClassName,
                   startIconClassName,
+                  !startIconOnClick && InputStartIconDisabledClassName,
                 )}
                 data-has-onclick={!!startIconOnClick}
                 name={startIcon}
@@ -120,6 +124,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
               UNSAFE_width={UNSAFE_width}
               className={InputSectionInputClassName}
               data-is-valid={isValid}
+              disabled={disableTextInput || isDisabled}
               hasEndIcon={!!endIcon}
               hasStartIcon={!!startIcon}
               inputSize={size}
@@ -138,6 +143,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
                   InputIconClassName,
                   InputEndIconClassName,
                   endIconClassName,
+                  !endIconOnClick && InputEndIconDisabledClassName,
                 )}
                 data-has-onclick={!!endIconOnClick}
                 name={endIcon}

--- a/packages/design-system/src/Input/Input.types.tsx
+++ b/packages/design-system/src/Input/Input.types.tsx
@@ -21,6 +21,8 @@ interface Props extends TextFieldProps {
   renderAs?: "input" | "textarea";
   /** (try not to) pass addition classes here */
   className?: string;
+  /** whether only input is disabled. */
+  disableTextInput?: boolean;
   /** label position  */
   labelPosition?: "top" | "left";
   /** name */

--- a/packages/design-system/src/NumberInput/NumberInput.tsx
+++ b/packages/design-system/src/NumberInput/NumberInput.tsx
@@ -112,7 +112,7 @@ const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>(
     };
 
     const handleChange = (_value: string, operation?: "add" | "subtract") => {
-      const inputValue = parseFloat(_value.replace(/[^0-9.-]+/g, ""));
+      const inputValue = getNumericalValue(_value);
 
       // Check if the input value is a valid number
       if (!isNaN(inputValue)) {
@@ -144,17 +144,20 @@ const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>(
 
     const checkMinViolation = (value: string): boolean => {
       if (typeof min === "number") {
-        return parseFloat(value.replace(/[^0-9.-]+/g, "")) <= min;
+        return getNumericalValue(value) <= min;
       }
       return false;
     };
 
     const checkMaxViolation = (value: string): boolean => {
       if (typeof max === "number") {
-        return parseFloat(value.replace(/[^0-9.-]+/g, "")) >= max;
+        return getNumericalValue(value) >= max;
       }
       return false;
     };
+
+    const getNumericalValue = (_value: string): number =>
+      parseFloat(_value.replace(/[^0-9.-]+/g, ""));
 
     return (
       <StyledNumberInput

--- a/packages/design-system/src/NumberInput/NumberInput.tsx
+++ b/packages/design-system/src/NumberInput/NumberInput.tsx
@@ -79,7 +79,7 @@ const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>(
           setDisableStartIcon(false);
         }
       }
-    }, [value, min, max]);
+    }, [value, min]);
 
     useEffect(() => {
       if (value) {

--- a/packages/design-system/src/NumberInput/NumberInput.types.ts
+++ b/packages/design-system/src/NumberInput/NumberInput.types.ts
@@ -16,6 +16,8 @@ export type NumberInputProps = InputProps & {
   labelPosition?: "top" | "left";
   /** Description of the input. */
   description?: string;
+  /** Whether text input is allowed. */
+  disableTextInput?: boolean;
   /** Error message of the input. Based on this, the input will show error state. */
   errorMessage?: string;
   /** Value */


### PR DESCRIPTION

## Description

1. Disable Icon clicks on NumberInput upon min-max violations.
2. Add another prop to disable text input only. ``disableTextInput``.


## Type of change
- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- Manual on storybook 


## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
