### PR TITLE
feat: replaced tooltip with copy button

### DIFF
--- a/.changeset/shiny-horses-walk.md
+++ b/.changeset/shiny-horses-walk.md
@@ -1,0 +1,5 @@
+---
+"@appsmithorg/design-system": patch
+---
+
+feat: replaced tooltip with copy button in category token documentation

--- a/packages/design-system/src/Documentation/components/CodeBlock.tsx
+++ b/packages/design-system/src/Documentation/components/CodeBlock.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import styled from "styled-components";
-import { Tooltip } from "Tooltip";
+import { Icon } from "Icon";
 import { toast } from "Toast";
 
 type CodeBlockProps = {
@@ -15,16 +15,14 @@ function CodeBlock({ code }: CodeBlockProps) {
         toast.show("Copied to clipboard", { kind: "success" });
       }}
     >
-      <Tooltip content="Click here to copy" mouseEnterDelay={0.7}>
-        <Code>{code}</Code>
-      </Tooltip>
+      <Code>{code}&nbsp;</Code>
+      <Icon name="copy-control" size="md" />
     </Wrapper>
   );
 }
 
 const Wrapper = styled.div`
   display: flex;
-  flex-direction: column;
   cursor: pointer;
   padding: 0 4px;
   border-radius: var(--ads-v2-border-radius);

--- a/packages/design-system/src/Documentation/components/CodeBlock.tsx
+++ b/packages/design-system/src/Documentation/components/CodeBlock.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import styled from "styled-components";
-import { Icon } from "Icon";
+import { Button } from "Button";
 import { toast } from "Toast";
 
 type CodeBlockProps = {
@@ -15,14 +15,15 @@ function CodeBlock({ code }: CodeBlockProps) {
         toast.show("Copied to clipboard", { kind: "success" });
       }}
     >
-      <Code>{code}&nbsp;</Code>
-      <Icon name="copy-control" size="md" />
+      <Code>{code}</Code>
+      <Button startIcon="copy-control" kind="tertiary" />
     </Wrapper>
   );
 }
 
 const Wrapper = styled.div`
   display: flex;
+  align-items: center;
   cursor: pointer;
   padding: 0 4px;
   border-radius: var(--ads-v2-border-radius);


### PR DESCRIPTION
## Description
Fixes https://github.com/appsmithorg/appsmith/issues/26847
Removed 'Tooltip' component and replaced it with 'Icon' component (copy).
<img width="642" alt="Screenshot 2023-12-18 at 6 44 09 PM" src="https://github.com/appsmithorg/design-system/assets/33133883/6552dc72-ac4b-4bad-9023-eb484eac78e8">

## Type of change
- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- Manual on storybook
- Tested for responsiveness

## Checklist:
### Dev activity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
