### PR TITLE
fix: Updated sm size for DatePicker, Input, Number Input, and Search Input

### DIFF
--- a/.changeset/smart-socks-learn.md
+++ b/.changeset/smart-socks-learn.md
@@ -1,0 +1,5 @@
+---
+"@appsmithorg/design-system": patch
+---
+
+fix: Updated sm size for DatePicker, Input, Number Input, and Search Input

--- a/packages/design-system/src/Input/Input.styles.tsx
+++ b/packages/design-system/src/Input/Input.styles.tsx
@@ -15,7 +15,7 @@ const Variables = css`
   --input-padding-x: var(--ads-v2-spaces-2); // padding left and right
   --input-padding-y: var(--ads-v2-spaces-2); // padding top and bottom
   --input-font-size: var(--ads-v2-font-size-2);
-  --input-height: 22px;
+  --input-height: 24px;
 `;
 
 const getSizes = (size: InputSizes, component: "input" | "textarea") => {
@@ -24,7 +24,7 @@ const getSizes = (size: InputSizes, component: "input" | "textarea") => {
       --input-padding-x: var(--ads-v2-spaces-2);
       --input-padding-y: var(--ads-v2-spaces-2);
       --input-font-size: var(--ads-v2-font-size-2);
-      --input-height: ${component === "input" ? "22px" : "60px"};
+      --input-height: ${component === "input" ? "24px" : "60px"};
     `,
     md: css`
       --input-padding-x: var(--ads-v2-spaces-3);

--- a/packages/design-system/src/SearchInput/SearchInput.styles.tsx
+++ b/packages/design-system/src/SearchInput/SearchInput.styles.tsx
@@ -7,13 +7,11 @@ const Sizes = {
     --input-font-size: 14px;
     --input-padding-x: var(--ads-v2-spaces-3); // padding left and right
     --input-padding-y: var(--ads-v2-spaces-2); // padding top and bottom
-    --input-height: 28px;
   `,
   md: css`
     --input-padding-x: var(--ads-v2-spaces-3);
     --input-padding-y: var(--ads-v2-spaces-3);
     --input-font-size: var(--ads-v2-font-size-4);
-    --input-height: 36px;
   `,
 };
 


### PR DESCRIPTION
## Description

Previously, Form input elements had different sm sizes.
Button             -> 24px
Datepicker      -> 22px
Input                -> 22px
Search Input   -> 28px
Number Input -> 22px
Select              -> 24px

This PR updates all these to 24px.


Fixes https://github.com/appsmithorg/appsmith/issues/34599

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Manual on storybook 
- Manual on main repo
- Jest
- Cypress

### Test Plan
> Add Testsmith test cases links that relate to this PR

### Issues raised during DP testing
> Link issues raised during DP testing for better visiblity and tracking (copy link from comments dropped on this PR)


## Checklist:
### Dev activity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


### QA activity:
- [ ] Test plan has been approved by relevant developers
- [ ] Test plan has been peer reviewed by QA
- [ ] Cypress test cases have been added and approved by either SDET or manual QA
- [ ] Organized project review call with relevant stakeholders after Round 1/2 of QA
- [ ] Added Test Plan Approved label after reveiwing all Cypress test
